### PR TITLE
[chore] Refactored variables

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -19,7 +19,6 @@ function Client (broker, conn, req) {
 
   // metadata
   this.connected = false
-  this.disconnected = false
   this.connackSent = false
   this.errored = false
 
@@ -34,6 +33,7 @@ function Client (broker, conn, req) {
   this.conn = conn
   conn.client = this
 
+  this._disconnected = false
   this._authorized = false
   this._parsingBatch = 1
   this._nextId = Math.ceil(Math.random() * 65535)
@@ -265,7 +265,7 @@ Client.prototype.close = function (done) {
   this._eos = nop
 
   function finish () {
-    if (!that.disconnected && that.will) {
+    if (!that._disconnected && that.will) {
       var will = Object.assign({}, that.will)
       that.broker.authorizePublish(that, will, function (err) {
         if (!err) {
@@ -291,7 +291,6 @@ Client.prototype.close = function (done) {
     conn.on('error', nop)
 
     that.connected = false
-    that.disconnected = true
 
     if (that.broker.clients[that.id] && that._authorized) {
       that.broker.unregisterClient(that)

--- a/lib/client.js
+++ b/lib/client.js
@@ -17,18 +17,29 @@ module.exports = Client
 function Client (broker, conn, req) {
   var that = this
 
+  // metadata
+  this.connected = false
+  this.disconnected = false
+  this.connackSent = false
+  this.errored = false
+
+  // mqtt params
+  this.id = null
+  this.clean = true
+
+  this.subscriptions = {}
+  this.duplicates = {}
+
   this.broker = broker
   this.conn = conn
+  conn.client = this
+
+  this._authorized = false
+  this._parsingBatch = 1
+  this._nextId = Math.ceil(Math.random() * 65535)
+
   this.req = req
-  this.parser = mqtt.parser()
-  this.connected = false
-  this.connackSent = false
-  this.authorized = false
-  this.errored = false
-  this.clean = true
-  this._handling = 0
-  this.subscriptions = {}
-  this.id = null
+  this.connDetails = null
 
   // we use two variables for the will
   // because we store in _will while
@@ -36,19 +47,9 @@ function Client (broker, conn, req) {
   this.will = null
   this._will = null
 
-  conn.client = this
-
-  this.parser.client = this
-
-  this.duplicates = {}
-  this._parsingBatch = 1
-  this._nextId = Math.ceil(Math.random() * 65535)
-
-  this.disconnected = false
-
-  this.connDetails = null
-
-  this.parser.on('packet', enqueue)
+  this._parser = mqtt.parser()
+  this._parser.client = this
+  this._parser.on('packet', enqueue)
 
   function nextBatch (err) {
     if (err) {
@@ -70,12 +71,12 @@ function Client (broker, conn, req) {
       if (!client.connackSent && client.broker.trustProxy && buf) {
         var { data } = client.broker.decodeProtocol(client, buf)
         if (data) {
-          client.parser.parse(data)
+          client._parser.parse(data)
         } else {
-          client.parser.parse(buf)
+          client._parser.parse(buf)
         }
       } else if (buf) {
-        client.parser.parse(buf)
+        client._parser.parse(buf)
       }
     }
   }
@@ -87,7 +88,7 @@ function Client (broker, conn, req) {
 
   conn.on('readable', nextBatch)
   conn.on('error', this.emit.bind(this, 'error'))
-  this.parser.on('error', this.emit.bind(this, 'error'))
+  this._parser.on('error', this.emit.bind(this, 'error'))
 
   conn.on('end', this.close.bind(this))
   this._eos = eos(this.conn, this.close.bind(this))
@@ -246,7 +247,7 @@ Client.prototype.close = function (done) {
     finish()
   }
 
-  this.parser.removeAllListeners('packet')
+  this._parser.removeAllListeners('packet')
   conn.removeAllListeners('readable')
 
   if (this._keepaliveTimer) {
@@ -292,7 +293,7 @@ Client.prototype.close = function (done) {
     that.connected = false
     that.disconnected = true
 
-    if (that.broker.clients[that.id] && that.authorized) {
+    if (that.broker.clients[that.id] && that._authorized) {
       that.broker.unregisterClient(that)
     }
 

--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -111,7 +111,7 @@ function authenticate (arg, done) {
       return
     }
     if (!err && successful) {
-      client.authorized = true
+      client._authorized = true
       return done()
     }
 

--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -49,8 +49,9 @@ function handle (client, packet, done) {
       handlePing(client, packet, done)
       break
     case 'disconnect':
+      // [MQTT-3.14.4-3]
+      client._disconnected = true
       // [MQTT-3.14.4-1]
-      client.disconnected = true
       client.conn.end()
       return
     default:

--- a/test/basic.js
+++ b/test/basic.js
@@ -231,21 +231,19 @@ test('disconnect', function (t) {
 })
 
 test('client closes', function (t) {
-  t.plan(7)
+  t.plan(5)
 
   var broker = aedes()
   var brokerClient
   var client = noError(connect(setup(broker, false), { clientId: 'abcde' }, function () {
     brokerClient = broker.clients.abcde
     t.equal(brokerClient.connected, true, 'client connected')
-    t.equal(brokerClient.disconnected, false)
     eos(client.conn, t.pass.bind('client closes'))
     setImmediate(() => {
       brokerClient.close(function () {
         t.equal(broker.clients.abcde, undefined, 'client instance is removed')
       })
       t.equal(brokerClient.connected, false, 'client disconnected')
-      t.equal(brokerClient.disconnected, true)
       broker.close(function (err) {
         t.error(err, 'no error')
         t.end()

--- a/test/will.js
+++ b/test/will.js
@@ -175,7 +175,7 @@ test('delete the will in the persistence after publish', function (t) {
 })
 
 test('delivers a will with authorization', function (t) {
-  t.plan(7)
+  t.plan(6)
 
   let authorized = false
   var opts = {}
@@ -189,7 +189,6 @@ test('delivers a will with authorization', function (t) {
 
   s.broker.on('clientDisconnect', function (client) {
     t.equal(client.connected, false)
-    t.equal(client.disconnected, true)
   })
 
   s.broker.mq.on('mywill', function (packet, cb) {
@@ -303,7 +302,7 @@ test('does not deliver will if keepalive is triggered during authentication', fu
   willConnect(setup(broker), opts)
 })
 
-// [MQTT-3.14.4-1]
+// [MQTT-3.14.4-3]
 test('does not deliver will when client sends a DISCONNECT', function (t) {
   t.plan(0)
 


### PR DESCRIPTION
- removed unused _handling var
- initialize authorized var to false and refactor it to a private var
- refactored parser var to a private var
- refactored disconnected var, it is a flag to control not to send Will when DISCONNECT, and not used to reflect the connection state.