### PR TITLE
[chore] Reject 2nd CONENCT while in preConnect

### DIFF
--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -11,18 +11,18 @@ var handlePing = require('./ping')
 
 function handle (client, packet, done) {
   if (packet.cmd === 'connect') {
-    if (client.connected) {
+    if (client.connected || !client._connectTimer) {
       // [MQTT-3.1.0-2]
-      client.conn.destroy()
-      return done(new Error('Invalid protocol'))
+      finish(client.conn, packet, done)
+      return
     }
     handleConnect(client, packet, done)
     return
   }
   if (!client.connected) {
     // [MQTT-3.1.0-1]
-    client.conn.destroy()
-    return done(new Error('Invalid protocol'))
+    finish(client.conn, packet, done)
+    return
   }
 
   switch (packet.cmd) {
@@ -61,6 +61,13 @@ function handle (client, packet, done) {
 
   if (client._keepaliveInterval > 0) {
     client._keepaliveTimer.reschedule(client._keepaliveInterval)
+  }
+
+  function finish (conn, packet, done) {
+    conn.destroy()
+    var error = new Error('Invalid protocol')
+    error.info = packet
+    done(error)
   }
 }
 

--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -62,13 +62,13 @@ function handle (client, packet, done) {
   if (client._keepaliveInterval > 0) {
     client._keepaliveTimer.reschedule(client._keepaliveInterval)
   }
+}
 
-  function finish (conn, packet, done) {
-    conn.destroy()
-    var error = new Error('Invalid protocol')
-    error.info = packet
-    done(error)
-  }
+function finish (conn, packet, done) {
+  conn.destroy()
+  var error = new Error('Invalid protocol')
+  error.info = packet
+  done(error)
 }
 
 module.exports = handle

--- a/test/close_socket_by_other_party.js
+++ b/test/close_socket_by_other_party.js
@@ -7,10 +7,7 @@ var aedes = require('../')
 var setup = helper.setup
 var connect = helper.connect
 var subscribe = helper.subscribe
-
-function sleep (ms) {
-  return new Promise((resolve, reject) => setTimeout(resolve, ms))
-}
+var delay = helper.delay
 
 test('client is closed before authenticate returns', function (t) {
   t.plan(2)
@@ -19,7 +16,7 @@ test('client is closed before authenticate returns', function (t) {
   var broker = aedes({
     authenticate: async (client, username, password, done) => {
       evt.emit('AuthenticateBegin', client)
-      await sleep(2000) // simulate network
+      await delay(2000) // simulate network
       done(null, true)
       evt.emit('AuthenticateEnd', client)
     }
@@ -56,7 +53,7 @@ test('client is closed before authorizePublish returns', function (t) {
   var broker = aedes({
     authorizePublish: async (client, packet, done) => {
       evt.emit('AuthorizePublishBegin', client)
-      await sleep(2000) // simulate latency writing to persistent store.
+      await delay(2000) // simulate latency writing to persistent store.
       done()
       evt.emit('AuthorizePublishEnd', client)
     }

--- a/test/connect.js
+++ b/test/connect.js
@@ -343,16 +343,22 @@ test('reject second CONNECT Packet sent while first CONNECT still in preConnect 
     t.equal(err.message, 'Invalid protocol')
   })
 
-  const msg = (s, ms, msg) => {
-    return new Promise((resolve) => {
-      setTimeout(() => { s.inStream.write(msg); resolve() }, ms)
-    })
+  const msg = async (s, ms, msg) => {
+    await delay(ms)
+    s.inStream.write(msg)
   }
 
-  Promise.all([msg(s, 100, packet1), msg(s, 200, packet2)]).then(() => {
-    broker.close()
-    t.end()
-  })
+  (async () => {
+    try {
+      await Promise.all([msg(s, 100, packet1), msg(s, 200, packet2)])
+      setImmediate(() => {
+        broker.close()
+        t.end()
+      })
+    } catch (error) {
+      t.fail(error)
+    }
+  })()
 })
 
 // [MQTT-3.1.2-1], Guarded in mqtt-packet

--- a/test/connect.js
+++ b/test/connect.js
@@ -5,6 +5,7 @@ var helper = require('./helper')
 var aedes = require('../')
 var setup = helper.setup
 var connect = helper.connect
+var delay = helper.delay
 var http = require('http')
 var ws = require('websocket-stream')
 var mqtt = require('mqtt')
@@ -304,6 +305,53 @@ test('second CONNECT Packet sent from a Client as a protocol violation and disco
       broker.close()
       t.end()
     })
+  })
+})
+
+test('reject second CONNECT Packet sent while first CONNECT still in preConnect stage', function (t) {
+  t.plan(2)
+
+  var packet1 = {
+    cmd: 'connect',
+    protocolId: 'MQTT',
+    protocolVersion: 4,
+    clean: true,
+    clientId: 'my-client-1',
+    keepalive: 0
+  }
+  var packet2 = {
+    cmd: 'connect',
+    protocolId: 'MQTT',
+    protocolVersion: 4,
+    clean: true,
+    clientId: 'my-client-2',
+    keepalive: 0
+  }
+
+  var i = 0
+  var broker = aedes({
+    preConnect: async function (client, done) {
+      var wait = i++ === 0 ? 2000 : 500
+      await delay(wait)
+      return done(null, true)
+    }
+  })
+  var s = setup(broker)
+
+  broker.on('connectionError', function (client, err) {
+    t.equal(err.info.clientId, 'my-client-2')
+    t.equal(err.message, 'Invalid protocol')
+  })
+
+  const msg = (s, ms, msg) => {
+    return new Promise((resolve) => {
+      setTimeout(() => { s.inStream.write(msg); resolve() }, ms)
+    })
+  }
+
+  Promise.all([msg(s, 100, packet1), msg(s, 200, packet2)]).then(() => {
+    broker.close()
+    t.end()
   })
 })
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -114,10 +114,13 @@ function subscribeMultiple (t, subscriber, subs, expectedGranted, done) {
   })
 }
 
+const delay = (time) => new Promise((resolve) => setTimeout(resolve, time))
+
 module.exports = {
   setup: setup,
   connect: connect,
   noError: noError,
   subscribe: subscribe,
-  subscribeMultiple: subscribeMultiple
+  subscribeMultiple: subscribeMultiple,
+  delay: delay
 }

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,9 +1,11 @@
 'use strict'
 
+var duplexify = require('duplexify')
 var mqtt = require('mqtt-connection')
 var through = require('through2')
+var util = require('util')
 var aedes = require('../')
-var duplexify = require('duplexify')
+
 var parseStream = mqtt.parseStream
 var generateStream = mqtt.generateStream
 var clients = 0
@@ -114,13 +116,11 @@ function subscribeMultiple (t, subscriber, subs, expectedGranted, done) {
   })
 }
 
-const delay = (time) => new Promise((resolve) => setTimeout(resolve, time))
-
 module.exports = {
   setup: setup,
   connect: connect,
   noError: noError,
   subscribe: subscribe,
   subscribeMultiple: subscribeMultiple,
-  delay: delay
+  delay: util.promisify(setTimeout)
 }


### PR DESCRIPTION
We have already followed [MQTT-3.1.0-2] spec to block 2nd CONNECT. This only applies to when `connected=true` clients. This PR is to stop any 2nd CONNECT even in the early preConnect stage where `connected=false`