### PR TITLE
[chore] Stop series of connect actions asap if broker is closed

### DIFF
--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -105,8 +105,9 @@ function authenticate (arg, done) {
     negate)
 
   function negate (err, successful) {
-    if (!client.connected) {
-      // a hack, sometimes close() happened before authenticate() comes back
+    if (!client.connected || client.broker.closed) {
+      // a hack, sometimes client.close() or broker.close() happened
+      // before authenticate() comes back
       // we stop here for not to register it and deregister it in write()
       return
     }

--- a/test/close_socket_by_other_party.js
+++ b/test/close_socket_by_other_party.js
@@ -7,15 +7,15 @@ var aedes = require('../')
 var setup = helper.setup
 var connect = helper.connect
 var subscribe = helper.subscribe
-var delay = helper.delay
 
 test('aedes is closed before client authenticate returns', function (t) {
   t.plan(0)
 
   var broker = aedes({
-    authenticate: async (client, username, password, done) => {
-      await delay(2000) // simulate network
-      done(null, true)
+    authenticate: (client, username, password, done) => {
+      setTimeout(function () {
+        done(null, true)
+      }, 2000)
     }
   })
   broker.on('client', function (client) {
@@ -41,9 +41,10 @@ test('client is closed before authenticate returns', function (t) {
   var broker = aedes({
     authenticate: async (client, username, password, done) => {
       evt.emit('AuthenticateBegin', client)
-      await delay(2000) // simulate network
-      done(null, true)
-      evt.emit('AuthenticateEnd', client)
+      setTimeout(function () {
+        done(null, true)
+        evt.emit('AuthenticateEnd', client)
+      }, 2000)
     }
   })
   broker.on('client', function (client) {
@@ -76,11 +77,13 @@ test('client is closed before authorizePublish returns', function (t) {
 
   var evt = new EE()
   var broker = aedes({
-    authorizePublish: async (client, packet, done) => {
+    authorizePublish: (client, packet, done) => {
       evt.emit('AuthorizePublishBegin', client)
-      await delay(2000) // simulate latency writing to persistent store.
-      done()
-      evt.emit('AuthorizePublishEnd', client)
+      // simulate latency writing to persistent store.
+      setTimeout(function () {
+        done()
+        evt.emit('AuthorizePublishEnd', client)
+      }, 2000)
     }
   })
   broker.on('clientError', function (client, err) {

--- a/test/close_socket_by_other_party.js
+++ b/test/close_socket_by_other_party.js
@@ -9,6 +9,31 @@ var connect = helper.connect
 var subscribe = helper.subscribe
 var delay = helper.delay
 
+test('aedes is closed before client authenticate returns', function (t) {
+  t.plan(0)
+
+  var broker = aedes({
+    authenticate: async (client, username, password, done) => {
+      await delay(2000) // simulate network
+      done(null, true)
+    }
+  })
+  broker.on('client', function (client) {
+    t.fail('should no client registration')
+  })
+  broker.on('connackSent', function () {
+    t.fail('should no connack be sent')
+  })
+  broker.on('clientError', function (client, err) {
+    t.error(err)
+  })
+
+  connect(setup(broker, 200))
+  broker.on('closed', () => {
+    t.end()
+  })
+})
+
 test('client is closed before authenticate returns', function (t) {
   t.plan(2)
 

--- a/test/connect.js
+++ b/test/connect.js
@@ -330,10 +330,11 @@ test('reject second CONNECT Packet sent while first CONNECT still in preConnect 
 
   var i = 0
   var broker = aedes({
-    preConnect: async function (client, done) {
-      var wait = i++ === 0 ? 2000 : 500
-      await delay(wait)
-      return done(null, true)
+    preConnect: function (client, done) {
+      var ms = i++ === 0 ? 2000 : 500
+      setTimeout(function () {
+        done(null, true)
+      }, ms)
     }
   })
   var s = setup(broker)

--- a/test/will.js
+++ b/test/will.js
@@ -182,7 +182,12 @@ test('delivers a will with authorization', function (t) {
   var opts = {}
   // willConnect populates opts with a will
   var s = willConnect(
-    setup(aedes({ authorizePublish: (_1, _2, callback) => { authorized = true; callback(null) } })),
+    setup(aedes({
+      authorizePublish: (client, packet, callback) => {
+        authorized = true
+        callback(null)
+      }
+    })),
     opts,
     function () {
       s.conn.destroy()
@@ -211,7 +216,12 @@ test('delivers a will waits for authorization', function (t) {
   var opts = {}
   // willConnect populates opts with a will
   var s = willConnect(
-    setup(aedes({ authorizePublish: (_1, _2, callback) => { authorized = true; setImmediate(() => { callback(null) }) } })),
+    setup(aedes({
+      authorizePublish: (client, packet, callback) => {
+        authorized = true
+        setImmediate(() => { callback(null) })
+      }
+    })),
     opts,
     function () {
       s.conn.destroy()
@@ -240,7 +250,12 @@ test('does not deliver a will without authorization', function (t) {
   var opts = {}
   // willConnect populates opts with a will
   var s = willConnect(
-    setup(aedes({ authorizePublish: (_1, _2, callback) => { authorized = true; callback(new Error()) } })),
+    setup(aedes({
+      authorizePublish: (username, packet, callback) => {
+        authorized = true
+        callback(new Error())
+      }
+    })),
     opts,
     function () {
       s.conn.destroy()
@@ -264,7 +279,12 @@ test('does not deliver a will without authentication', function (t) {
   var opts = {}
   // willConnect populates opts with a will
   var s = willConnect(
-    setup(aedes({ authenticate: (_1, _2, _3, callback) => { authenticated = true; callback(new Error(), false) } })),
+    setup(aedes({
+      authenticate: (client, username, password, callback) => {
+        authenticated = true
+        callback(new Error(), false)
+      }
+    })),
     opts)
 
   s.broker.once('clientError', function () {
@@ -319,6 +339,7 @@ test('does not deliver will when client sends a DISCONNECT', function (t) {
 
   s.broker.mq.on('mywill', function (packet, cb) {
     t.fail(packet)
+    cb()
   })
 
   broker.on('closed', t.end.bind(t))
@@ -336,7 +357,7 @@ test('does not store multiple will with same clientid', function (t) {
     })
   })
 
-  broker.on('clientDisconnect', function (c) {
+  broker.on('clientDisconnect', function (client) {
     // reconnect same client with will
     s = willConnect(setup(broker, false), opts, function () {
       // check that there are not 2 will messages for the same clientid

--- a/test/will.js
+++ b/test/will.js
@@ -6,7 +6,6 @@ var helper = require('./helper')
 var aedes = require('../')
 var setup = helper.setup
 var connect = helper.connect
-var delay = helper.delay
 
 function willConnect (s, opts, connected) {
   opts = opts || {}
@@ -304,9 +303,10 @@ test('does not deliver will if broker is closed during authentication', function
   var opts = {}
   opts.keepalive = 1
   var broker = aedes({
-    authenticate: async function (client, username, password, callback) {
-      await delay(3000)
-      callback(null, true)
+    authenticate: function (client, username, password, callback) {
+      setTimeout(function () {
+        callback(null, true)
+      }, 3000)
     }
   })
 


### PR DESCRIPTION
Once broker is closed while in authentication, we stop processing pending actions (e.g. set keepalive, restore subscriptions, register clients etc.) as quick as possible in resource wise.
