### PR TITLE
Fix protocolDecoder phase

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -70,10 +70,14 @@ function Client (broker, conn, req) {
       that._parsingBatch = 0
       var buf = empty
       buf = client.conn.read(null)
-      if (!client.connackSent && client.broker.trustProxy && buf) {
-        var { data } = client.broker.decodeProtocol(client, buf)
-        if (data) {
-          client._parser.parse(data)
+      if (!client.connackSent && buf) {
+        var proto = client.broker.decodeProtocol(client, buf)
+        if (proto) {
+          if (proto.data) {
+            client._parser.parse(proto.data)
+          } else if (!proto.isProxy) {
+            client._parser.parse(buf)
+          }
         } else {
           client._parser.parse(buf)
         }

--- a/lib/protocol-decoder.js
+++ b/lib/protocol-decoder.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var proxyProtocol = require('proxy-protocol-js')
+var forwarded = require('forwarded')
 
 var v1ProxyProtocolSignature = Buffer.from('PROXY ', 'utf8')
 var v2ProxyProtocolSignature = Buffer.from([
@@ -59,9 +60,16 @@ function protocolDecoder (client, data) {
     var headers = client.req && client.req.headers ? client.req.headers : null
     var proxyProto
     if (headers) {
-      if (headers['x-real-ip']) proto.ipAddress = headers['x-real-ip']
-      else if (headers['x-forwarded-for']) proto.ipAddress = headers['x-forwarded-for']
+      if (headers['x-forwarded-for']) {
+        var addresses = forwarded(client.req)
+        proto.ipAddress = headers['x-real-ip'] ? headers['x-real-ip'] : addresses[addresses.length - 1]
+        proto.serverIpAddress = addresses[0]
+      }
+      if (headers['x-real-ip']) {
+        proto.ipAddress = headers['x-real-ip']
+      }
       proto.port = socket._socket.remotePort
+      ipFamily = socket._socket.remoteFamily
       proto.isWebsocket = true
     }
     if (isValidV1ProxyProtocol(data)) {
@@ -70,6 +78,7 @@ function protocolDecoder (client, data) {
         ipFamily = proxyProto.inetProtocol
         proto.ipAddress = proxyProto.source.ipAddress
         proto.port = proxyProto.source.port
+        proto.serverIpAddress = proxyProto.destination.ipAddress
         proto.data = proxyProto.data
         proto.isProxy = 1
       }
@@ -77,13 +86,15 @@ function protocolDecoder (client, data) {
       proxyProto = proxyProtocol.V2ProxyProtocol.parse(data)
       if (proxyProto && proxyProto.proxyAddress && proxyProto.data) {
         if (proxyProto.proxyAddress instanceof proxyProtocol.IPv4ProxyAddress) {
-          ipFamily = 'IPv4'
           proto.ipAddress = proxyProto.proxyAddress.sourceAddress.address.join('.')
           proto.port = proxyProto.proxyAddress.sourceAddress.address.port
+          proto.serverIpAddress = proxyProto.proxyAddress.destinationAddress.address.join('.')
+          ipFamily = 'IPv4'
         } else if (proxyProto.proxyAddress instanceof proxyProtocol.IPv6ProxyAddress) {
-          ipFamily = 'IPv6'
           proto.ipAddress = parseIpV6Array(proxyProto.proxyAddress.sourceAddress.address)
           proto.port = proxyProto.proxyAddress.sourceAddress.address.port
+          proto.serverIpAddress = parseIpV6Array(proxyProto.proxyAddress.destinationAddress.address)
+          ipFamily = 'IPv6'
         }
         proto.isProxy = 2
         if (Buffer.isBuffer(proxyProto.data)) {
@@ -99,10 +110,12 @@ function protocolDecoder (client, data) {
       proto.isWebsocket = true
       proto.ipAddress = socket._socket.remoteAddress
       proto.port = socket._socket.remotePort
+      proto.serverIpAddress = socket._socket.address().address
       ipFamily = socket._socket.remoteFamily
     } else if (socket.address) {
       proto.ipAddress = socket.remoteAddress
       proto.port = socket.remotePort
+      proto.serverIpAddress = socket.address().address
       ipFamily = socket.remoteFamily
     }
   }
@@ -119,6 +132,9 @@ function protocolDecoder (client, data) {
   }
   if (proto.port) {
     client.connDetails.port = proto.port
+  }
+  if (proto.serverIpAddress) {
+    client.connDetails.serverIpAddress = proto.serverIpAddress
   }
   client.connDetails.ipFamily = proto.ipFamily
   client.connDetails.isProxy = proto.isProxy

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "fastfall": "^1.5.1",
     "fastparallel": "^2.3.0",
     "fastseries": "^1.7.2",
+    "forwarded": "^0.1.2",
     "from2": "^2.3.0",
     "mqemitter": "^3.0.0",
     "mqtt-packet": "^6.3.0",


### PR DESCRIPTION
- Removed assignement destructuring ( in nextBatch ) in case a developer provide its own protocolDecoder that would return something else than an object.

- Changed packet parsing condition to fix #364 

- Extract serverAddress in protocolDecoder ( use forwarded package for WS headers ) to prepare for #338 

- Added test mocking TCP proxy behaviour, but might require a test with Nginx and/or HAproxy