### PR TITLE
Fixed duplicate emitting error event

### DIFF
--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -72,7 +72,6 @@ function init (client, packet, done) {
   if (returnCode > 0) {
     var error = new Error(errorMessages[returnCode])
     error.errorCode = returnCode
-    client.broker.emit('clientError', client, error)
     doConnack(
       { client: client, returnCode: returnCode, sessionPresent: false },
       done.bind(this, error))
@@ -129,7 +128,6 @@ function authenticate (arg, done) {
     }
     var error = new Error(errorMessages[arg.returnCode])
     error.errorCode = arg.returnCode
-    client.broker.emit('clientError', client, error)
     arg.client = client
     doConnack(arg,
       // [MQTT-3.2.2-5]

--- a/test/connect.js
+++ b/test/connect.js
@@ -66,6 +66,9 @@ test('reject client requested for unacceptable protocol version', function (t) {
     t.equal(packet.returnCode, 1, 'unacceptable protocol version')
     t.equal(broker.connectedClients, 0)
   })
+  broker.on('clientError', function (client, err) {
+    t.fail('should not raise clientError error')
+  })
   broker.on('connectionError', function (client, err) {
     t.equal(err.message, 'unacceptable protocol version')
   })

--- a/test/will.js
+++ b/test/will.js
@@ -286,7 +286,7 @@ test('does not deliver a will without authentication', function (t) {
     })),
     opts)
 
-  s.broker.once('clientError', function () {
+  s.broker.on('clientError', function () {
     t.equal(authenticated, true, 'authentication called')
     t.end()
   })


### PR DESCRIPTION
We have already emitt errors in callback, it is not necessary to explicitly emit error by ourselves