### PR TITLE
Allow user defined their error auth message

### DIFF
--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -121,21 +121,23 @@ function authenticate (arg, done) {
 
     if (err) {
       const errCode = err.returnCode
-      if (errCode && (errCode >= 1 && errCode <= 3)) {
+      if (errCode && (errCode >= 2 && errCode <= 5)) {
         arg.returnCode = errCode
       } else {
-        // If errorCode is 4 or not a number
-        arg.returnCode = 4
+        arg.returnCode = 5
+      }
+      if (!err.message) {
+        err.message = errorMessages[arg.returnCode]
       }
     } else {
       arg.returnCode = 5
+      err = new Error(errorMessages[arg.returnCode])
     }
-    var error = new Error(errorMessages[arg.returnCode])
-    error.errorCode = arg.returnCode
+    err.errorCode = arg.returnCode
     arg.client = client
     doConnack(arg,
       // [MQTT-3.2.2-5]
-      client.close.bind(client, done.bind(this, error)))
+      client.close.bind(client, done.bind(this, err)))
   }
 }
 


### PR DESCRIPTION
- User could define their own auth error message raised in `clientError`
- no custom error message / empty error message will be applied to the internal one
- User could define the CONNACK return code between 2 and 5. If out of ranges, 5 instead.