### PR TITLE
Fixed tests & use readable-stream

### DIFF
--- a/aedes.js
+++ b/aedes.js
@@ -1,17 +1,17 @@
 'use strict'
 
-const mqemitter = require('mqemitter')
 const EE = require('events').EventEmitter
 const util = require('util')
-const memory = require('aedes-persistence')
 const parallel = require('fastparallel')
 const series = require('fastseries')
 const uuidv4 = require('uuid/v4')
-const Packet = require('aedes-packet')
 const bulk = require('bulk-write-stream')
 const reusify = require('reusify')
+const { pipeline } = require('readable-stream')
+const Packet = require('aedes-packet')
+const memory = require('aedes-persistence')
+const mqemitter = require('mqemitter')
 const Client = require('./lib/client')
-const { pipeline } = require('stream')
 
 module.exports = Aedes.Server = Aedes
 

--- a/package.json
+++ b/package.json
@@ -69,9 +69,9 @@
   "license": "MIT",
   "devDependencies": {
     "@sinonjs/fake-timers": "^6.0.0",
-    "@types/node": "^12.12.26",
-    "@typescript-eslint/eslint-plugin": "^2.19.0",
-    "@typescript-eslint/parser": "^2.19.0",
+    "@types/node": "^12.12.27",
+    "@typescript-eslint/eslint-plugin": "^2.19.2",
+    "@typescript-eslint/parser": "^2.19.2",
     "concat-stream": "^2.0.0",
     "duplexify": "^4.1.1",
     "license-checker": "^25.0.1",
@@ -85,7 +85,7 @@
     "websocket-stream": "^5.5.0"
   },
   "dependencies": {
-    "aedes-packet": "^2.1.0",
+    "aedes-packet": "^2.3.0",
     "aedes-persistence": "^7.2.1",
     "aedes-protocol-decoder": "^1.0.0",
     "bulk-write-stream": "^2.0.1",

--- a/test/auth.js
+++ b/test/auth.js
@@ -444,7 +444,6 @@ test('authorize publish', function (t) {
     t.notOk(Object.prototype.hasOwnProperty.call(packet, 'messageId'), 'should not contain messageId in QoS 0')
     expected.brokerId = s.broker.id
     expected.brokerCounter = s.broker.counter
-    delete expected.dup
     delete expected.length
     t.deepEqual(packet, expected, 'packet matches')
     cb()
@@ -492,7 +491,6 @@ test('authorize waits for authenticate', function (t) {
     t.notOk(Object.prototype.hasOwnProperty.call(packet, 'messageId'), 'should not contain messageId in QoS 0')
     expected.brokerId = s.broker.id
     expected.brokerCounter = s.broker.counter
-    delete expected.dup
     delete expected.length
     t.deepEqual(packet, expected, 'packet matches')
     cb()
@@ -542,7 +540,6 @@ test('authorize publish from configOptions', function (t) {
     t.notOk(Object.prototype.hasOwnProperty.call(packet, 'messageId'), 'should not contain messageId in QoS 0')
     expected.brokerId = s.broker.id
     expected.brokerCounter = s.broker.counter
-    delete expected.dup
     delete expected.length
     t.deepEqual(packet, expected, 'packet matches')
     cb()

--- a/test/basic.js
+++ b/test/basic.js
@@ -27,7 +27,8 @@ test('publish QoS 0', function (t) {
     topic: 'hello',
     payload: Buffer.from('world'),
     qos: 0,
-    retain: false
+    retain: false,
+    dup: false
   }
 
   s.broker.mq.on('hello', function (packet, cb) {

--- a/test/client-pub-sub.js
+++ b/test/client-pub-sub.js
@@ -183,7 +183,8 @@ test('emit a `ack` event on PUBACK for QoS 1 [clean=false]', function (t) {
     topic: 'hello',
     payload: Buffer.from('world'),
     qos: 1,
-    retain: false
+    retain: false,
+    dup: false
   }
 
   broker.on('clientReady', function (client) {
@@ -676,7 +677,8 @@ test('programmatically add custom subscribe', function (t) {
     topic: 'hello',
     payload: Buffer.from('world'),
     qos: 0,
-    retain: false
+    retain: false,
+    dup: false
   }
   subscribe(t, s, 'hello', 0, function () {
     broker.subscribe('hello', deliver, function () {
@@ -714,6 +716,7 @@ test('custom function in broker.subscribe', function (t) {
     payload: Buffer.from('world'),
     qos: 1,
     retain: false,
+    dup: false,
     messageId: undefined
   }
   connect(s, {}, function () {

--- a/test/qos1.js
+++ b/test/qos1.js
@@ -88,7 +88,8 @@ test('publish QoS 1 and check offline queue', function (t) {
     payload: 'world',
     qos: 1,
     messageId: 10,
-    retain: false
+    retain: false,
+    dup: false
   }
   var queue = []
   subscribe(t, subscriber, 'hello', 1, function () {

--- a/test/qos2.js
+++ b/test/qos2.js
@@ -206,6 +206,7 @@ test('call published method with client with QoS 2', function (t) {
       payload: Buffer.from('world'),
       qos: 2,
       retain: false,
+      dup: false,
       messageId: undefined
     }
     const expected = {
@@ -555,6 +556,7 @@ test('multiple publish and store one', function (t) {
     payload: Buffer.from('world'),
     qos: 2,
     retain: false,
+    dup: false,
     messageId: 42
   }
 


### PR DESCRIPTION
- use `readable-stream` rather than `stream`
- fix tests after updating aedes-packet to v2.3.0