### PR TITLE
Added test on unrecognised params in sub packet structure

### DIFF
--- a/test/meta.js
+++ b/test/meta.js
@@ -154,7 +154,7 @@ test('emit subscribe event', function (t) {
 })
 
 test('emit subscribe event if unrecognized params in subscribe packet structure', function (t) {
-  t.plan(2)
+  t.plan(3)
 
   const broker = aedes()
   t.tearDown(broker.close.bind(broker))
@@ -170,7 +170,9 @@ test('emit subscribe event if unrecognized params in subscribe packet structure'
   s.client.subscribe({
     subscriptions: subs,
     restore: true
-  }, function () {})
+  }, function (err) {
+    t.error(err)
+  })
 })
 
 test('emit unsubscribe event', function (t) {

--- a/test/meta.js
+++ b/test/meta.js
@@ -153,6 +153,26 @@ test('emit subscribe event', function (t) {
   })
 })
 
+test('emit subscribe event if unrecognized params in subscribe packet structure', function (t) {
+  t.plan(2)
+
+  const broker = aedes()
+  t.tearDown(broker.close.bind(broker))
+
+  const s = noError(connect(setup(broker)))
+  const subs = [{ topic: 'hello', qos: 0 }]
+
+  broker.on('subscribe', function (subscriptions, client) {
+    t.equal(subscriptions, subs)
+    t.deepEqual(client, s.client)
+  })
+
+  s.client.subscribe({
+    subscriptions: subs,
+    restore: true
+  }, function () {})
+})
+
 test('emit unsubscribe event', function (t) {
   t.plan(6)
 


### PR DESCRIPTION
In https://github.com/moscajs/aedes/pull/408, we remove the `restore` extra key in subscription packet structure, not to break aedes logic.