### PR TITLE
fix: catch writeToStream errors

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -4,13 +4,17 @@ const mqtt = require('mqtt-packet')
 
 function write (client, packet, done) {
   if (client.conn.writable && (client.connecting || client.connected)) {
-    const result = mqtt.writeToStream(packet, client.conn)
-    if (!result && !client.errored && done) {
-      client.conn.once('drain', done)
-      return
-    }
-    if (done) {
-      setImmediate(done)
+    try {
+      const result = mqtt.writeToStream(packet, client.conn)
+      if (!result && !client.errored && done) {
+        client.conn.once('drain', done)
+        return
+      }
+      if (done) {
+        setImmediate(done)
+      }
+    } catch (err) {
+      setImmediate(client._onError.bind(client, new Error('packet received not valid')))
     }
   } else {
     setImmediate(client._onError.bind(client, new Error('connection closed')))

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "mqtt": "^4.0.0",
     "mqtt-connection": "^4.0.0",
     "pre-commit": "^1.2.2",
+    "proxyquire": "^2.1.3",
     "release-it": "^13.5.7",
     "snazzy": "^8.0.0",
     "standard": "^14.3.3",


### PR DESCRIPTION
@mcollina this should fix unhandled expections when a non-valid packet is write to stream