### PR TITLE
fix: write leaks

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -105,7 +105,10 @@ function Client (broker, conn, req) {
       setImmediate(() => {
         var packet = new Packet(toForward, broker)
         packet.qos = 0
-        write(that, packet, cb)
+        write(that, packet, function (err) {
+          that._onError(err)
+          cb() // don't pass the error here or it will be thrown be mqemitter
+        })
       })
     } else {
       setImmediate(cb)
@@ -171,6 +174,7 @@ function writeQoS (err, client, packet) {
   if (err) {
     // is this right, or we should ignore thins?
     client.emit('error', err)
+    packet.writeCallback(err)
   } else {
     write(client, packet, packet.writeCallback)
   }
@@ -181,6 +185,8 @@ function drainRequest (req) {
 }
 
 function onError (err) {
+  if (!err) return
+
   this.errored = true
   this.conn.removeAllListeners('error')
   this.conn.on('error', noop)

--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -213,10 +213,12 @@ function registerClient (arg, done) {
 function doConnack (arg, done) {
   const client = arg.client || this.client
   const connack = new Connack(arg)
-  write(client, connack, function () {
-    client.broker.emit('connackSent', connack, client)
-    client.connackSent = true
-    done()
+  write(client, connack, function (err) {
+    if (!err) {
+      client.broker.emit('connackSent', connack, client)
+      client.connackSent = true
+    }
+    done(err)
   })
 }
 

--- a/lib/handlers/publish.js
+++ b/lib/handlers/publish.js
@@ -39,13 +39,21 @@ function enqueuePublish (packet, done) {
 
   switch (packet.qos) {
     case 2:
-      write(client, new PubRec(packet), function () {
-        client.broker.persistence.incomingStorePacket(client, packet, done)
+      write(client, new PubRec(packet), function (err) {
+        if (err) {
+          done(err)
+        } else {
+          client.broker.persistence.incomingStorePacket(client, packet, done)
+        }
       })
       break
     case 1:
-      write(client, new PubAck(packet), function () {
-        client.broker.publish(packet, client, done)
+      write(client, new PubAck(packet), function (err) {
+        if (err) {
+          done(err)
+        } else {
+          client.broker.publish(packet, client, done)
+        }
       })
       break
     case 0:

--- a/lib/qos-packet.js
+++ b/lib/qos-packet.js
@@ -6,7 +6,7 @@ const util = require('util')
 function QoSPacket (original, client) {
   Packet.call(this, original, client.broker)
 
-  this.writeCallback = noop
+  this.writeCallback = client._onError.bind(client)
 
   if (!original.messageId) {
     this.messageId = client._nextId
@@ -21,7 +21,5 @@ function QoSPacket (original, client) {
 }
 
 util.inherits(QoSPacket, Packet)
-
-function noop () {}
 
 module.exports = QoSPacket

--- a/lib/write.js
+++ b/lib/write.js
@@ -3,22 +3,22 @@
 const mqtt = require('mqtt-packet')
 
 function write (client, packet, done) {
-  if (client.conn.writable && (client.connecting || client.connected)) {
+  var error = null
+  if (client.connecting || client.connected) {
     try {
       const result = mqtt.writeToStream(packet, client.conn)
-      if (!result && !client.errored && done) {
+      if (!result && !client.errored) {
         client.conn.once('drain', done)
         return
       }
-      if (done) {
-        setImmediate(done)
-      }
-    } catch (err) {
-      setImmediate(client._onError.bind(client, new Error('packet received not valid')))
+    } catch (e) {
+      error = new Error('packet received not valid')
     }
   } else {
-    setImmediate(client._onError.bind(client, new Error('connection closed')))
+    error = new Error('connection closed')
   }
+
+  setImmediate(done, error, client)
 }
 
 module.exports = write

--- a/test/basic.js
+++ b/test/basic.js
@@ -132,7 +132,7 @@ test('publish empty topic throws error', function (t) {
 })
 
 // Catch invalid packet writeToStream errors
-test('catch write errors', function (t) {
+test('return write errors to callback', function (t) {
   t.plan(1)
 
   const write = proxyquire('../lib/write.js', {
@@ -151,7 +151,7 @@ test('catch write errors', function (t) {
   }
 
   write(client, {}, function (err) {
-    t.equal(err.message, 'packet received not valid', 'should catch the error')
+    t.equal(err.message, 'packet received not valid', 'should return the error to callback')
   })
 })
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -147,13 +147,12 @@ test('catch write errors', function (t) {
     conn: {
       writable: true
     },
-    connecting: true,
-    _onError: (err) => {
-      t.equal(err.message, 'packet received not valid', 'should catch the error')
-    }
+    connecting: true
   }
 
-  write(client, {})
+  write(client, {}, function (err) {
+    t.equal(err.message, 'packet received not valid', 'should catch the error')
+  })
 })
 
 ;[{ qos: 0, clean: false }, { qos: 0, clean: true }, { qos: 1, clean: false }, { qos: 1, clean: true }].forEach(function (ele) {

--- a/test/qos1.js
+++ b/test/qos1.js
@@ -56,6 +56,30 @@ test('publish QoS 1 throws error', function (t) {
   })
 })
 
+test('publish QoS 1 throws error on write', function (t) {
+  t.plan(1)
+
+  const s = connect(setup())
+  t.tearDown(s.broker.close.bind(s.broker))
+
+  s.broker.on('client', function (client) {
+    client.connected = false
+    client.connecting = false
+
+    s.inStream.write({
+      cmd: 'publish',
+      topic: 'hello',
+      payload: 'world',
+      qos: 1,
+      messageId: 42
+    })
+  })
+
+  s.broker.on('clientError', function (client, err) {
+    t.equal(err.message, 'connection closed', 'throws error')
+  })
+})
+
 test('publish QoS 1 and check offline queue', function (t) {
   t.plan(13)
 

--- a/test/qos2.js
+++ b/test/qos2.js
@@ -119,6 +119,30 @@ test('subscribe QoS 2', function (t) {
   })
 })
 
+test('publish QoS 2 throws error on write', function (t) {
+  t.plan(1)
+
+  const s = connect(setup())
+  t.tearDown(s.broker.close.bind(s.broker))
+
+  s.broker.on('client', function (client) {
+    client.connected = false
+    client.connecting = false
+
+    s.inStream.write({
+      cmd: 'publish',
+      topic: 'hello',
+      payload: 'world',
+      qos: 2,
+      messageId: 42
+    })
+  })
+
+  s.broker.on('clientError', function (client, err) {
+    t.equal(err.message, 'connection closed', 'throws error')
+  })
+})
+
 test('client.publish with clean=true subscribption QoS 2', function (t) {
   t.plan(8)
 


### PR DESCRIPTION
Actually [write](https://github.com/moscajs/aedes/blob/master/lib/write.js#L5) doesn't return errors to done callback but insteed it calls `client._onError` that will emit a clientError/connectionError event and disconnect the client. This could cause some memory leaks as when an error occurs the write callback is never called