### PR TITLE
fix: no such packet error with QoS 2

### DIFF
--- a/lib/handlers/publish.js
+++ b/lib/handlers/publish.js
@@ -39,11 +39,11 @@ function enqueuePublish (packet, done) {
 
   switch (packet.qos) {
     case 2:
-      write(client, new PubRec(packet), function (err) {
+      client.broker.persistence.incomingStorePacket(client, packet, function (err) {
         if (err) {
           done(err)
         } else {
-          client.broker.persistence.incomingStorePacket(client, packet, done)
+          write(client, new PubRec(packet), done)
         }
       })
       break

--- a/test/qos2.js
+++ b/test/qos2.js
@@ -648,7 +648,7 @@ test('packet is written to stream after being stored', function (t) {
 
   s.outStream.once('data', function (packet) {
     t.equal(packet.cmd, 'pubrec', 'pubrec received')
-    t.equal(packetStored, true, 'after being stored stored')
+    t.equal(packetStored, true, 'after packet store')
     t.end()
   })
 })

--- a/test/qos2.js
+++ b/test/qos2.js
@@ -618,3 +618,37 @@ test('multiple publish and store one', function (t) {
     })
   })
 })
+
+test('packet is written to stream after being stored', function (t) {
+  const s = connect(setup())
+
+  var broker = s.broker
+
+  t.tearDown(broker.close.bind(s.broker))
+
+  var packetStored = false
+
+  var fn = broker.persistence.incomingStorePacket.bind(broker.persistence)
+
+  s.broker.persistence.incomingStorePacket = function (client, packet, done) {
+    packetStored = true
+    t.pass('packet stored')
+    fn(client, packet, done)
+  }
+
+  const packet = {
+    cmd: 'publish',
+    topic: 'hello',
+    payload: 'world',
+    qos: 2,
+    messageId: 42
+  }
+
+  publish(t, s, packet)
+
+  s.outStream.once('data', function (packet) {
+    t.equal(packet.cmd, 'pubrec', 'pubrec received')
+    t.equal(packetStored, true, 'after being stored stored')
+    t.end()
+  })
+})


### PR DESCRIPTION
When a qos2 publish is received, `client.broker.persistence.incomingStorePacket` was called after writing the packet to the stream, this was causing some race conditions that could cause the error explained in #509 issue


Fixes #509 
