### PR TITLE
fix: don't pass writeQos errors in packet cb

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -174,12 +174,14 @@ function writeQoS (err, client, packet) {
   if (err) {
     // is this right, or we should ignore thins?
     client.emit('error', err)
+    // don't pass the error here or it will be thrown be mqemitter
     packet.writeCallback()
   } else {
     write(client, packet, function (err) {
       if (err) {
         client.emit('error', err)
       }
+      // don't pass the error here or it will be thrown be mqemitter
       packet.writeCallback()
     })
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -107,7 +107,7 @@ function Client (broker, conn, req) {
         packet.qos = 0
         write(that, packet, function (err) {
           that._onError(err)
-          cb() // don't pass the error here or it will be thrown be mqemitter
+          cb() // don't pass the error here or it will be thrown by mqemitter
         })
       })
     } else {
@@ -174,14 +174,14 @@ function writeQoS (err, client, packet) {
   if (err) {
     // is this right, or we should ignore thins?
     client.emit('error', err)
-    // don't pass the error here or it will be thrown be mqemitter
+    // don't pass the error here or it will be thrown by mqemitter
     packet.writeCallback()
   } else {
     write(client, packet, function (err) {
       if (err) {
         client.emit('error', err)
       }
-      // don't pass the error here or it will be thrown be mqemitter
+      // don't pass the error here or it will be thrown by mqemitter
       packet.writeCallback()
     })
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -174,9 +174,14 @@ function writeQoS (err, client, packet) {
   if (err) {
     // is this right, or we should ignore thins?
     client.emit('error', err)
-    packet.writeCallback(err)
+    packet.writeCallback()
   } else {
-    write(client, packet, packet.writeCallback)
+    write(client, packet, function (err) {
+      if (err) {
+        client.emit('error', err)
+      }
+      packet.writeCallback()
+    })
   }
 }
 

--- a/test/client-pub-sub.js
+++ b/test/client-pub-sub.js
@@ -457,7 +457,7 @@ test('subscribe throws error when QoS > 0', function (t) {
   const broker = aedes()
   t.tearDown(broker.close.bind(broker))
 
-  broker.on('client', function (client) {
+  broker.on('clientReady', function (client) {
     client.subscribe({
       topic: 'hello',
       qos: 1
@@ -478,7 +478,7 @@ test('subscribe throws error when QoS > 0', function (t) {
     })
   })
 
-  broker.once('clientError', function (client, error) {
+  broker.on('clientError', function (client, error) {
     t.equal(error.message, 'connection closed', 'should throw clientError')
   })
 


### PR DESCRIPTION
deliverQos/deliver0 functions are bounded in subscribe and used then by mqemitters to deliver messages to clients, the callbacks of those functions should NEVER return an error in callback as it is not catched by mqemitter and could cause unhandled exceptions