### PR TITLE
fix: `emptyQueue` hitting its high water mark

### DIFF
--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -232,7 +232,11 @@ function emptyQueue (arg, done) {
     outgoing,
     through(function clearQueue (data, enc, next) {
       const packet = new QoSPacket(data, client)
-      packet.writeCallback = next
+      // Here we are deliberatly passing only the error
+      // This is because there is no destination stream so the "client"
+      // Object filled the buffer up to the highWaterMark preventing stored messages
+      // being sent
+      packet.writeCallback = (error, _client) => next(error)
       persistence.outgoingUpdate(client, packet, emptyQueueFilter)
     }),
     done


### PR DESCRIPTION
This is the same issue as reported here:
https://github.com/rvagg/through2/issues/32#issuecomment-62645342


This orignial filled the streams internal buffer because there is no destination stream.
The "client" object returned as the second argument in `writeCallback` was trying to be forwarded