### PR TITLE
feat(bridge): support incoming mosquitto bridge connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Check Docker docs [here](https://github.com/moscajs/aedes-cli#docker)
 - [Dynamic Topics][dynamic_topics] Support
 - MQTT Bridge Support between aedes
 - [MQTT 5.0][mqttv5] _(not support yet)_
-- [Bridge Protocol][bridge_protocol]
+- [Bridge Protocol][bridge_protocol] _(incoming connections only)_
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ Other info:
 
 - The repo [aedes-tests](https://github.com/moscajs/aedes-tests) is used to test aedes with clusters and different emitters/persistences. Check its source code to have a starting point on how to work with clusters
 
+## Bridge connections
+
+Normally, when publishing a message, the `retain` flag is consumed by Aedes and
+then set to `false` so that recipients of the message do not retain it as well.
+
+Brokers that support the [Bridge Protocol][bridge_protocol] can connect to
+Aedes.  When connecting with this special protocol, subscriptions work as usual
+excecpt that the `retain` flag in the packet is propagated as-is.
+
 ## Exensions
 
 - [aedes-logging]: Logging module for Aedes, based on Pino

--- a/README.md
+++ b/README.md
@@ -98,11 +98,16 @@ Other info:
 ## Bridge connections
 
 Normally, when publishing a message, the `retain` flag is consumed by Aedes and
-then set to `false` so that recipients of the message do not retain it as well.
+then set to `false`.  This is done for two reasons:
+
+- MQTT-3.3.1-9 states that it MUST set the RETAIN flag to 0 when a PUBLISH
+  Packet is sent to a Client because it matches an established subscription
+  regardless of how the flag was set in the message it received.
+- When operating as a cluster, only one Aedes node may store the packet
 
 Brokers that support the [Bridge Protocol][bridge_protocol] can connect to
 Aedes.  When connecting with this special protocol, subscriptions work as usual
-excecpt that the `retain` flag in the packet is propagated as-is.
+except that the `retain` flag in the packet is propagated as-is.
 
 ## Exensions
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Check Docker docs [here](https://github.com/moscajs/aedes-cli#docker)
 - [Dynamic Topics][dynamic_topics] Support
 - MQTT Bridge Support between aedes
 - [MQTT 5.0][mqttv5] _(not support yet)_
-- [Bridge Protocol][bridge_protocol] _(not support yet)_
+- [Bridge Protocol][bridge_protocol]
 
 ## Examples
 

--- a/aedes.js
+++ b/aedes.js
@@ -256,11 +256,46 @@ Aedes.prototype.publish = function (packet, client, done) {
   this._series(new PublishState(this, client, packet), publishFuncs, p, done)
 }
 
-Aedes.prototype.subscribe = function (topic, func, done) {
+function createRetainToFalseWrapper (broker, topic, func) {
+  func._retainToFalseWrappers = func._wrappers || {}
+  func._retainToFalseWrappers[topic] = func._retainToFalseWrappers[topic] || {}
+  func._retainToFalseWrappers[topic][broker] = function handlePacketSubscription (_packet, cb) {
+    _packet = new Packet(_packet, broker)
+    _packet.retain = false
+    func(_packet, cb)
+  }
+  func._retainToFalseWrappers[topic][broker]._freeWrapper = function freeWrapper () {
+    delete ((func._retainToFalseWrappers || {})[topic] || {})[broker]
+    if (Object.keys((func._retainToFalseWrappers || {})[topic] || {}).length === 0) {
+      delete func._retainToFalseWrappers[topic]
+    }
+    if (Object.keys(func._retainToFalseWrappers).length === 0) {
+      delete func._retainToFalseWrappers
+    }
+  }
+  return func._retainToFalseWrappers[topic][broker]
+}
+
+Aedes.prototype.subscribe = function (topic, func, rap, done) {
+  if (done === undefined && typeof rap === 'function') {
+    done = rap
+    rap = false
+  }
+  if (!rap) {
+    func = createRetainToFalseWrapper(this, topic, func)
+  }
   this.mq.on(topic, func, done)
 }
 
 Aedes.prototype.unsubscribe = function (topic, func, done) {
+  if (func) {
+    func = ((func._retainToFalseWrappers || {})[topic] || {})[this] || func
+  }
+
+  if (func && func._freeWrapper) {
+    func._freeWrapper()
+  }
+
   this.mq.removeListener(topic, func, done)
 }
 

--- a/aedes.js
+++ b/aedes.js
@@ -170,7 +170,6 @@ function storeRetained (packet, done) {
 }
 
 function emitPacket (packet, done) {
-  packet.retain = false
   this.broker.mq.emit(packet, done)
 }
 

--- a/docs/Aedes.md
+++ b/docs/Aedes.md
@@ -20,7 +20,7 @@
   - [Event: connackSent](#event-connacksent)
   - [Event: closed](#event-closed)
   - [aedes.handle (stream)](#aedeshandle-stream)
-  - [aedes.subscribe (topic, deliverfunc, callback)](#aedessubscribe-topic-deliverfunc-callback)
+  - [aedes.subscribe (topic, deliverfunc\[, retainAsPublised\], callback)](#aedessubscribe-topic-deliverfunc-callback)
   - [aedes.unsubscribe (topic, deliverfunc, callback)](#aedesunsubscribe-topic-deliverfunc-callback)
   - [aedes.publish (packet, callback)](#aedespublish-packet-callback)
   - [aedes.close ([callback])](#aedesclose-callback)
@@ -176,15 +176,18 @@ const aedes = require('./aedes')()
 const server = require('net').createServer(aedes.handle)
 ```
 
-## aedes.subscribe (topic, deliverfunc, callback)
+## aedes.subscribe (topic, deliverfunc\[, retainAsPublised\], callback)
 
 - topic: `<string>`
+- retainAsPublished: `<boolean>`
 - deliverfunc: `<Function>` `(packet, cb) => void`
   - packet: `<aedes-packet>` & [`PUBLISH`][PUBLISH]
   - cb: `<Function>`
 - callback: `<Function>`
 
 Directly subscribe a `topic` in server side. Bypass [`authorizeSubscribe`](#handler-authorizesubscribe-client-subscription-callback)
+
+If `retainAsPublished` is `true` (default `false`), the retain flag in the packet is passed to `deliverFunc` as it was published.  Otherwise, it is set to `false` before being passed to `deliverFunc`.
 
 The `topic` and `deliverfunc` is a compound key to differentiate the uniqueness of its subscription pool. `topic` could be the one that is existed, in this case `deliverfunc` will be invoked as well as `SUBSCRIBE` does.
 

--- a/docs/Aedes.md
+++ b/docs/Aedes.md
@@ -20,7 +20,7 @@
   - [Event: connackSent](#event-connacksent)
   - [Event: closed](#event-closed)
   - [aedes.handle (stream)](#aedeshandle-stream)
-  - [aedes.subscribe (topic, deliverfunc\[, retainAsPublised\], callback)](#aedessubscribe-topic-deliverfunc-callback)
+  - [aedes.subscribe (topic, deliverfunc, callback)](#aedessubscribe-topic-deliverfunc-callback)
   - [aedes.unsubscribe (topic, deliverfunc, callback)](#aedesunsubscribe-topic-deliverfunc-callback)
   - [aedes.publish (packet, callback)](#aedespublish-packet-callback)
   - [aedes.close ([callback])](#aedesclose-callback)
@@ -176,18 +176,15 @@ const aedes = require('./aedes')()
 const server = require('net').createServer(aedes.handle)
 ```
 
-## aedes.subscribe (topic, deliverfunc\[, retainAsPublised\], callback)
+## aedes.subscribe (topic, deliverfunc, callback)
 
 - topic: `<string>`
-- retainAsPublished: `<boolean>`
 - deliverfunc: `<Function>` `(packet, cb) => void`
   - packet: `<aedes-packet>` & [`PUBLISH`][PUBLISH]
   - cb: `<Function>`
 - callback: `<Function>`
 
 Directly subscribe a `topic` in server side. Bypass [`authorizeSubscribe`](#handler-authorizesubscribe-client-subscription-callback)
-
-If `retainAsPublished` is `true` (default `false`), the retain flag in the packet is passed to `deliverFunc` as it was published.  Otherwise, it is set to `false` before being passed to `deliverFunc`.
 
 The `topic` and `deliverfunc` is a compound key to differentiate the uniqueness of its subscription pool. `topic` could be the one that is existed, in this case `deliverfunc` will be invoked as well as `SUBSCRIBE` does.
 

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -23,9 +23,12 @@ function SubAck (packet, granted) {
   this.granted = granted
 }
 
-function Subscription (qos, func) {
+function Subscription (qos, func, rh, rap, nl) {
   this.qos = qos
   this.func = func
+  this.rh = rh
+  this.rap = rap
+  this.nl = nl
 }
 
 function SubscribeState (client, packet, restore, finish) {
@@ -36,10 +39,13 @@ function SubscribeState (client, packet, restore, finish) {
   this.subState = []
 }
 
-function SubState (client, packet, granted) {
+function SubState (client, packet, granted, rh, rap, nl) {
   this.client = client
   this.packet = packet
   this.granted = granted
+  this.rh = rh
+  this.rap = rap
+  this.nl = nl
 }
 
 // if same subscribed topic in subs array, we pick up the last one
@@ -66,7 +72,7 @@ function handleSubscribe (client, packet, restore, done) {
 }
 
 function doSubscribe (sub, done) {
-  const s = new SubState(this.client, this.packet, sub.qos)
+  const s = new SubState(this.client, this.packet, sub.qos, sub.rh, sub.rap, sub.nl)
   this.subState.push(s)
   this.actions.call(s, sub, done)
 }
@@ -119,7 +125,18 @@ function addSubs (sub, done) {
   const broker = client.broker
   const topic = sub.topic
   const qos = sub.qos
-  let func = qos > 0 ? client.deliverQoS : client.deliver0
+  const rh = this.rh
+  const rap = this.rap
+  const nl = this.nl
+  const deliverFunc = qos > 0 ? client.deliverQoS : client.deliver0
+
+  let func = function handlePacketSubscription (_packet, cb) {
+    if (!rap) {
+      _packet = new Packet(_packet, broker)
+      _packet.retain = false
+    }
+    deliverFunc(_packet, cb)
+  }
 
   // [MQTT-4.7.2-1]
   if (isStartsWithWildcard(topic)) {
@@ -127,11 +144,11 @@ function addSubs (sub, done) {
   }
 
   if (!client.subscriptions[topic]) {
-    client.subscriptions[topic] = new Subscription(qos, func)
+    client.subscriptions[topic] = new Subscription(qos, func, rh, rap, nl)
     broker.subscribe(topic, func, done)
-  } else if (client.subscriptions[topic].qos !== qos) {
+  } else if (client.subscriptions[topic].qos !== qos || client.subscriptions[topic].rh !== rh || client.subscriptions[topic].rap !== rap || client.subscriptions[topic].nl !== nl) {
     broker.unsubscribe(topic, client.subscriptions[topic].func)
-    client.subscriptions[topic] = new Subscription(qos, func)
+    client.subscriptions[topic] = new Subscription(qos, func, rh, rap, nl)
     broker.subscribe(topic, func, done)
   } else {
     done()

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -141,6 +141,15 @@ function addSubs (sub, done) {
   const nl = this.nl
   let func = qos > 0 ? client.deliverQoS : client.deliver0
 
+  if (!rap) {
+    const deliverFunc = func
+    func = function handlePacketSubscription (_packet, cb) {
+      _packet = new Packet(_packet, broker)
+      _packet.retain = false
+      deliverFunc(_packet, cb)
+    }
+  }
+
   // [MQTT-4.7.2-1]
   if (isStartsWithWildcard(topic)) {
     func = blockDollarSignTopics(func)
@@ -148,11 +157,11 @@ function addSubs (sub, done) {
 
   if (!client.subscriptions[topic]) {
     client.subscriptions[topic] = new Subscription(qos, func, rh, rap, nl)
-    broker.subscribe(topic, func, rap, done)
+    broker.subscribe(topic, func, done)
   } else if (client.subscriptions[topic].qos !== qos || client.subscriptions[topic].rh !== rh || client.subscriptions[topic].rap !== rap || client.subscriptions[topic].nl !== nl) {
     broker.unsubscribe(topic, client.subscriptions[topic].func)
     client.subscriptions[topic] = new Subscription(qos, func, rh, rap, nl)
-    broker.subscribe(topic, func, rap, done)
+    broker.subscribe(topic, func, done)
   } else {
     done()
   }

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -141,15 +141,6 @@ function addSubs (sub, done) {
   const nl = this.nl
   let func = qos > 0 ? client.deliverQoS : client.deliver0
 
-  if (!rap) {
-    const deliverFunc = func
-    func = function handlePacketSubscription (_packet, cb) {
-      _packet = new Packet(_packet, broker)
-      _packet.retain = false
-      deliverFunc(_packet, cb)
-    }
-  }
-
   // [MQTT-4.7.2-1]
   if (isStartsWithWildcard(topic)) {
     func = blockDollarSignTopics(func)
@@ -157,11 +148,11 @@ function addSubs (sub, done) {
 
   if (!client.subscriptions[topic]) {
     client.subscriptions[topic] = new Subscription(qos, func, rh, rap, nl)
-    broker.subscribe(topic, func, done)
+    broker.subscribe(topic, func, rap, done)
   } else if (client.subscriptions[topic].qos !== qos || client.subscriptions[topic].rh !== rh || client.subscriptions[topic].rap !== rap || client.subscriptions[topic].nl !== nl) {
     broker.unsubscribe(topic, client.subscriptions[topic].func)
     client.subscriptions[topic] = new Subscription(qos, func, rh, rap, nl)
-    broker.subscribe(topic, func, done)
+    broker.subscribe(topic, func, rap, done)
   } else {
     done()
   }

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -26,8 +26,19 @@ function SubAck (packet, granted) {
 function Subscription (qos, func, rh, rap, nl) {
   this.qos = qos
   this.func = func
+
+  // retain-handling indicates how retained messages should be
+  // handled when a new subscription is created
+  // (see [MQTT-3.3.1-9] through [MQTT-3.3.1-11])
   this.rh = rh
+
+  // retain-as-published indicates whether to leave the retain flag as-is (true)
+  // or to clear it before sending to subscriptions (false) default false
+  // (see [MQTT-3.3.1-12] through [MQTT-3.3.1-13])
   this.rap = rap
+
+  // no-local indicates that a client should not receive its own
+  // messages (see [MQTT-3.8.3-3])
   this.nl = nl
 }
 
@@ -128,14 +139,15 @@ function addSubs (sub, done) {
   const rh = this.rh
   const rap = this.rap
   const nl = this.nl
-  const deliverFunc = qos > 0 ? client.deliverQoS : client.deliver0
+  let func = qos > 0 ? client.deliverQoS : client.deliver0
 
-  let func = function handlePacketSubscription (_packet, cb) {
-    if (!rap) {
+  if (!rap) {
+    const deliverFunc = func
+    func = function handlePacketSubscription (_packet, cb) {
       _packet = new Packet(_packet, broker)
       _packet.retain = false
+      deliverFunc(_packet, cb)
     }
-    deliverFunc(_packet, cb)
   }
 
   // [MQTT-4.7.2-1]

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "fastseries": "^2.0.0",
     "hyperid": "^2.0.5",
     "mqemitter": "^4.4.0",
-    "mqtt-packet": "^6.7.0",
+    "mqtt-packet": "^6.9.0",
     "readable-stream": "^3.6.0",
     "retimer": "^2.0.0",
     "reusify": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "test"
   ],
   "tsd": {
-		"directory": "test/types"
-	},
+    "directory": "test/types"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/moscajs/aedes.git"

--- a/test/client-pub-sub.js
+++ b/test/client-pub-sub.js
@@ -451,6 +451,89 @@ test('subscribe a client programmatically', function (t) {
   })
 })
 
+test('subscribe a client programmatically clears retain', function (t) {
+  t.plan(3)
+
+  const broker = aedes()
+  t.tearDown(broker.close.bind(broker))
+
+  const expected = {
+    cmd: 'publish',
+    topic: 'hello',
+    payload: Buffer.from('world'),
+    dup: false,
+    length: 12,
+    qos: 0,
+    retain: false
+  }
+
+  broker.on('client', function (client) {
+    client.subscribe({
+      topic: 'hello',
+      qos: 0
+    }, function (err) {
+      t.error(err, 'no error')
+
+      broker.publish({
+        topic: 'hello',
+        payload: Buffer.from('world'),
+        qos: 0,
+        retain: true
+      }, function (err) {
+        t.error(err, 'no error')
+      })
+    })
+  })
+
+  const s = connect(setup(broker))
+
+  s.outStream.once('data', function (packet) {
+    t.deepEqual(packet, expected, 'packet matches')
+  })
+})
+
+test('subscribe a bridge programmatically keeps retain', function (t) {
+  t.plan(3)
+
+  const broker = aedes()
+  t.tearDown(broker.close.bind(broker))
+
+  const expected = {
+    cmd: 'publish',
+    topic: 'hello',
+    payload: Buffer.from('world'),
+    dup: false,
+    length: 12,
+    qos: 0,
+    retain: true
+  }
+
+  broker.on('client', function (client) {
+    client.subscribe({
+      topic: 'hello',
+      qos: 0,
+      rap: true
+    }, function (err) {
+      t.error(err, 'no error')
+
+      broker.publish({
+        topic: 'hello',
+        payload: Buffer.from('world'),
+        qos: 0,
+        retain: true
+      }, function (err) {
+        t.error(err, 'no error')
+      })
+    })
+  })
+
+  const s = connect(setup(broker))
+
+  s.outStream.once('data', function (packet) {
+    t.deepEqual(packet, expected, 'packet matches')
+  })
+})
+
 test('subscribe throws error when QoS > 0', function (t) {
   t.plan(3)
 


### PR DESCRIPTION
The incoming mosquitto bridge connections add 128 to the protocol
version to indicate ras=true and nl=true.

Support for this was added in mqtt-packet with
https://github.com/mqttjs/mqtt-packet/pull/106

Subscriptions from these connections will have ras=true and nl=true

When publishing to these connections, aedes will now
copy the Packet and set retain to false only if ras is not true.

Fixes #329 