### PR TITLE
fix: set the dup flag for QoS 2

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -124,10 +124,13 @@ function Client (broker, conn, req) {
         if (clientSub && (clientSub.qos || 0) < packet.qos) {
           packet.qos = clientSub.qos
         }
-        packet.writeCallback = cb
         if (that.clean || packet.retain) {
+          packet.writeCallback = cb
           writeQoS(null, that, packet)
         } else {
+          packet.writeCallback = () => {
+            packet.setDupIfNecessary(broker.persistence, that, cb)
+          }
           broker.persistence.outgoingUpdate(that, packet, writeQoS)
         }
       })

--- a/lib/client.js
+++ b/lib/client.js
@@ -129,6 +129,7 @@ function Client (broker, conn, req) {
           writeQoS(null, that, packet)
         } else {
           packet.writeCallback = () => {
+            // [MQTT-3.3.1-1]
             packet.setDupIfNecessary(broker.persistence, that, cb)
           }
           broker.persistence.outgoingUpdate(that, packet, writeQoS)

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,7 +6,7 @@ const util = require('util')
 const eos = require('end-of-stream')
 const Packet = require('aedes-packet')
 const write = require('./write')
-const QoSPacket = require('./qos-packet')
+const { QoSPacket, setDupIfNecessary } = require('./qos-packet')
 const handleSubscribe = require('./handlers/subscribe')
 const handleUnsubscribe = require('./handlers/unsubscribe')
 const handle = require('./handlers')
@@ -130,7 +130,7 @@ function Client (broker, conn, req) {
         } else {
           packet.writeCallback = () => {
             // [MQTT-3.3.1-1]
-            packet.setDupIfNecessary(broker.persistence, that, cb)
+            setDupIfNecessary(packet, broker.persistence, that, cb)
           }
           broker.persistence.outgoingUpdate(that, packet, writeQoS)
         }

--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -3,7 +3,7 @@
 const retimer = require('retimer')
 const { pipeline } = require('readable-stream')
 const write = require('../write')
-const QoSPacket = require('../qos-packet')
+const { QoSPacket, setDupIfNecessary } = require('../qos-packet')
 const { through } = require('../utils')
 const handleSubscribe = require('./subscribe')
 const uniqueId = require('hyperid')()
@@ -262,7 +262,7 @@ function emptyQueueFilter (err, client, packet) {
   } else {
     write(client, packet, () => {
       // [MQTT-3.3.1-1]
-      packet.setDupIfNecessary(persistence, client, next)
+      setDupIfNecessary(packet, persistence, client, next)
     })
   }
 }

--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -261,6 +261,7 @@ function emptyQueueFilter (err, client, packet) {
     persistence.outgoingClearMessageId(client, packet, next)
   } else {
     write(client, packet, () => {
+      // [MQTT-3.3.1-1]
       packet.setDupIfNecessary(persistence, client, next)
     })
   }

--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -260,7 +260,9 @@ function emptyQueueFilter (err, client, packet) {
   if (client.clean || !authorized) {
     persistence.outgoingClearMessageId(client, packet, next)
   } else {
-    write(client, packet, next)
+    write(client, packet, () => {
+      packet.setDupIfNecessary(persistence, client, next)
+    })
   }
 }
 

--- a/lib/qos-packet.js
+++ b/lib/qos-packet.js
@@ -18,6 +18,14 @@ function QoSPacket (original, client) {
   } else {
     this.messageId = original.messageId
   }
+
+  this.setDupIfNecessary = (persistence, client, cb) => {
+    if (this.qos === 2) {
+      persistence.outgoingUpdate(client, { ...this, dup: true }, cb)
+    } else {
+      cb()
+    }
+  }
 }
 
 util.inherits(QoSPacket, Packet)

--- a/lib/qos-packet.js
+++ b/lib/qos-packet.js
@@ -18,16 +18,19 @@ function QoSPacket (original, client) {
   } else {
     this.messageId = original.messageId
   }
+}
 
-  this.setDupIfNecessary = (persistence, client, cb) => {
-    if (this.qos === 2) {
-      persistence.outgoingUpdate(client, { ...this, dup: true }, cb)
-    } else {
-      cb()
-    }
+function setDupIfNecessary (packet, persistence, client, cb) {
+  if (packet.qos === 2) {
+    persistence.outgoingUpdate(client, { ...packet, dup: true }, cb)
+  } else {
+    cb()
   }
 }
 
 util.inherits(QoSPacket, Packet)
 
-module.exports = QoSPacket
+module.exports = {
+  QoSPacket,
+  setDupIfNecessary
+}

--- a/test/qos2.js
+++ b/test/qos2.js
@@ -653,6 +653,7 @@ test('packet is written to stream after being stored', function (t) {
   })
 })
 
+// [MQTT-3.3.1-1]
 test('re-delivery for client with the same id has dup=true', function (t) {
   t.plan(9)
 
@@ -686,6 +687,7 @@ test('re-delivery for client with the same id has dup=true', function (t) {
   })
 })
 
+// [MQTT-3.3.1-1]
 test('setting dup for one subscriber doesn\'t affect another', function (t) {
   t.plan(12)
 
@@ -725,6 +727,7 @@ test('setting dup for one subscriber doesn\'t affect another', function (t) {
   })
 })
 
+// [MQTT-3.3.1-1]
 test('dup is also set if the message is not acked upon connecting', function (t) {
   t.plan(9)
 


### PR DESCRIPTION
This PR adds setting the `dup` flag for re-deliveries of QoS 2 packets.

It requires [complementary changes](https://github.com/tomekt-bolt/aedes-persistence/commit/eeb85d94226ed31eefaf3fad26c5bf3179bdfb7a) in the `aedes-persistence` project and possibly some adjustments in concrete persistence layer implementations.