### PR TITLE
chore(types): include types/packet in aedes.d.ts

### DIFF
--- a/aedes.d.ts
+++ b/aedes.d.ts
@@ -4,5 +4,6 @@ export declare function aedes (options?: AedesOptions): Aedes
 export declare function Server (options?: AedesOptions): Aedes
 
 export * from './types/instance'
+export * from './types/packet'
 export * from './types/client'
 export default aedes


### PR DESCRIPTION
missing the "export * from './types/packet"  in order to have packet types available (typescript)