### PR TITLE
fix: upgrade Aedes.d.ts and Client to extends from EventEmitter

### DIFF
--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -1,7 +1,7 @@
 import { IncomingMessage } from 'http'
 import { PublishPacket, SubscribePacket, Subscription, Subscriptions, UnsubscribePacket } from './packet'
 import { Connection } from './instance'
-import EventEmitter from 'events'
+import { EventEmitter } from 'events'
 
 export interface Client extends EventEmitter {
   id: Readonly<string>

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -1,8 +1,9 @@
 import { IncomingMessage } from 'http'
 import { PublishPacket, SubscribePacket, Subscription, Subscriptions, UnsubscribePacket } from './packet'
 import { Connection } from './instance'
+import EventEmitter from 'events'
 
-export interface Client {
+export interface Client extends EventEmitter {
   id: Readonly<string>
   clean: Readonly<boolean>
   version: Readonly<number>

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -2,7 +2,7 @@ import { Duplex } from 'stream'
 import { Socket } from 'net'
 import { Client } from './client'
 import type { AedesPublishPacket, ConnectPacket, ConnackPacket, Subscription, PingreqPacket, PublishPacket, PubrelPacket } from './packet'
-import EventEmitter from 'events'
+import { EventEmitter } from 'events'
 
 type LastHearthbeatTimestamp = Date;
 

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -2,6 +2,7 @@ import { Duplex } from 'stream'
 import { Socket } from 'net'
 import { Client } from './client'
 import type { AedesPublishPacket, ConnectPacket, ConnackPacket, Subscription, PingreqPacket, PublishPacket, PubrelPacket } from './packet'
+import EventEmitter from 'events'
 
 type LastHearthbeatTimestamp = Date;
 
@@ -56,7 +57,7 @@ export interface AedesOptions {
   published?: PublishedHandler
 }
 
-export interface Aedes {
+export interface Aedes extends EventEmitter {
   id: Readonly<string>
   connectedClients: Readonly<number>
   closed: Readonly<boolean>


### PR DESCRIPTION
Aedes and Client interfaces has been upgraded as an extends from EventEmitter in order to allow a complete events management in TypeScript applications