### PR TITLE
fix/typings: Remove Readonly<T> from AuthenticateHandler params

### DIFF
--- a/test/types/aedes.test-d.ts
+++ b/test/types/aedes.test-d.ts
@@ -1,4 +1,5 @@
 import { expectType } from 'tsd'
+import { timingSafeEqual } from 'crypto'
 import { Socket } from 'net'
 import type {
   Aedes,
@@ -27,8 +28,8 @@ const broker = Server({
       callback(new Error('connection error'), false)
     }
   },
-  authenticate: (client: Client, username: Readonly<string>, password: Readonly<Buffer>, callback) => {
-    if (username === 'test' && password === Buffer.from('test') && client.version === 4) {
+  authenticate: (client: Client, username: string, password: Buffer, callback) => {
+    if (username === 'test' && timingSafeEqual(password, Buffer.from('test')) && client.version === 4) {
       callback(null, true)
     } else {
       const error = new Error() as AuthenticateError

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -27,8 +27,8 @@ type PreConnectHandler = (client: Client, packet: ConnectPacket, callback: (erro
 
 type AuthenticateHandler = (
   client: Client,
-  username: Readonly<string>,
-  password: Readonly<Buffer>,
+  username: string,
+  password: Buffer,
   done: (error: AuthenticateError | null, success: boolean | null) => void
 ) => void
 


### PR DESCRIPTION
This commit removes the Readonly<T> wrappings around the `username` and `password` params to the `AuthenticateHandler` interface, which were added in #596.

The motivation for this change is that when `password` is `Readonly<Buffer>`, the type is incompatible with `crypto.timingSafeEqual`, which is the function Aedes users should be using to compare raw, sensitive buffers with each other.
Because `Readonly<Buffer>` is incompatible with `crypto.timingSafeEqual`, users end up having to cast with `password as Buffer`, which largely defeats the purpose of marking it `Readonly` in the first place and introduces casting in security-related areas of the code where it's not really needed in the first place.

The error it gives is:

    No overload matches this call.
      Overload 1 of 2, '(a: ArrayBufferView, b: ArrayBufferView): boolean', gave the following error.
        Argument of type 'Readonly<Buffer>' is not assignable to parameter of type 'ArrayBufferView'.
          Type 'Readonly<Buffer>' is missing the following properties from type 'Float32Array': [Symbol.iterator], [Symbol.toStringTag]
      Overload 2 of 2, '(a: ArrayBufferView, b: ArrayBufferView): boolean', gave the following error.
        Argument of type 'Readonly<Buffer>' is not assignable to parameter of type 'ArrayBufferView'.ts(2769)

Removing it from `username` has no effect, because strings are already immutable in JavaScript, and TypeScript will automatically treat it as if it were just `string`.