### PR TITLE
Add username from CONNECT to client after authenticate succes

### DIFF
--- a/docs/Client.md
+++ b/docs/Client.md
@@ -72,6 +72,15 @@ It is available only after `CONNACK (rc=0)`, otherwise it is `null` in cases:
 - after `CONNACK (rc!=0)` response
 - `connectionError` raised by aedes
 
+## client.username
+
+- `<string>` __Default__: `null`
+
+Client username, specified by CONNECT packet.
+
+It is available only after a successful call to `aedes.authenticate()`, where it
+will be set to the username specifed by the client, or `null` if no username was supplied.
+
 ## client.clean
 
 - `<boolean>` __Default__: `true`

--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -98,9 +98,10 @@ function init (client, packet, done) {
 function authenticate (arg, done) {
   const client = this.client
   client.pause()
+  let username = this.username;
   client.broker.authenticate(
     client,
-    this.packet.username,
+    username,
     this.packet.password,
     negate)
 
@@ -113,6 +114,7 @@ function authenticate (arg, done) {
     }
     if (!err && successful) {
       client._authorized = true
+      client.username = username || null;
       return done()
     }
 


### PR DESCRIPTION
Re issue https://github.com/moscajs/aedes/issues/147, the basic requirement in any authentication scheme is knowing the username specified during the CONNECT phase. So I think this really should be in the core API, rather than added by users.

This patch adds a that as the `Client.username`  property.