### PR TITLE
Update Aedes.md on('publish') description

### DIFF
--- a/docs/Aedes.md
+++ b/docs/Aedes.md
@@ -112,8 +112,7 @@ Emitted when timeout happes in the `client` keepalive.
 
 - `packet` `<aedes-packet>` & [`PUBLISH`][PUBLISH]
 - `client` [`<Client>`](./Client.md) | `null`
-
-Emitted when servers delivers the `packet` to subscribed `client`. If there are no clients subscribed to the `packet` topic, server still publish the `packet` and emit the event. `client` is `null` when `packet` is an internal message like aedes heartbeat message and LWT.
+Emitted when server receives `packet` from the `client`. `client` is `null` when `packet` is an internal message like aedes heartbeat message and LWT.
 
 > _Note! `packet` belongs `aedes-packet` type. Some properties belongs to aedes internal, any changes on them will break aedes internal flow._
 


### PR DESCRIPTION
Description seems incorrect. `publish` event is emitted when client **sends** message