### PR TITLE
feat: add a prefix in aedes module and drop ts functions

### DIFF
--- a/aedes.d.ts
+++ b/aedes.d.ts
@@ -1,9 +1,3 @@
-import { Aedes, AedesOptions } from './types/instance'
-
-export declare function aedes (options?: AedesOptions): Aedes
-export declare function Server (options?: AedesOptions): Aedes
-
-export * from './types/instance'
-export * from './types/packet'
-export * from './types/client'
-export default aedes
+/// <reference path="./types/instance.d.ts" />
+/// <reference path="./types/client.d.ts" />
+/// <reference path="./types/packet.d.ts" />

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "aedes.d.ts",
   "scripts": {
     "lint": "npm run lint:standard && npm run lint:typescript && npm run lint:markdown",
-    "lint:fix": "standard --fix",
+    "lint:fix": "standard --fix && eslint -c types/.eslintrc.json --fix aedes.d.ts types/**/*.ts test/types/**/*.test-d.ts",
     "lint:standard": "standard --verbose | snazzy",
     "lint:typescript": "eslint -c types/.eslintrc.json aedes.d.ts types/**/*.ts test/types/**/*.test-d.ts",
     "lint:markdown": "markdownlint docs/*.md README.md",

--- a/test/types/aedes.test-d.ts
+++ b/test/types/aedes.test-d.ts
@@ -1,17 +1,18 @@
+/// <reference path="../../aedes.d.ts" />
+
+import type { AedesPublishPacket, ConnackPacket, ConnectPacket, PingreqPacket, PublishPacket, PubrelPacket, SubscribePacket, Subscription, UnsubscribePacket } from 'aedes:packet'
+import type { AuthenticateError, Brokers, Connection } from 'aedes:server'
+import Server, { Aedes } from 'aedes:server'
+
+import type { Client } from 'aedes:client'
+import { Socket } from 'node:net'
 import { expectType } from 'tsd'
-import { Socket } from 'net'
-import type {
-  Aedes,
-  Brokers,
-  AuthenticateError,
-  Client,
-  Connection
-} from '../../aedes'
-import { Server } from '../../aedes'
-import type { AedesPublishPacket, ConnackPacket, ConnectPacket, PingreqPacket, PublishPacket, PubrelPacket, Subscription, SubscribePacket, UnsubscribePacket } from '../../types/packet'
 
 // Aedes server
-const broker = Server({
+let broker = new Server()
+expectType<Aedes>(broker)
+
+broker = new Aedes({
   id: 'aedes',
   concurrency: 100,
   heartbeatInterval: 60000,

--- a/types/.eslintrc.json
+++ b/types/.eslintrc.json
@@ -1,7 +1,6 @@
 {
   "extends": [
     "eslint:recommended",
-    "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
     "standard"
   ],
@@ -15,16 +14,19 @@
     "createDefaultProgram": true
   },
   "rules": {
+    "linebreak-style": ["warn", "unix"],
     "no-console": "off",
-    "@typescript-eslint/indent": ["error", 2],
     "semi": ["error", "never"],
-    "import/export": "off" // this errors on multiple exports (overload interfaces)
+    "import/export": "off", // this errors on multiple exports (overload interfaces)
+    "@typescript-eslint/indent": ["error", 2]
   },
   "overrides": [
     {
-      "files": ["*.d.ts","*.test-d.ts"],
+      "files": ["*.d.ts", "*.test-d.ts"],
       "rules": {
-        "@typescript-eslint/no-explicit-any": "off"
+        "no-dupe-class-members": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/triple-slash-reference": "off"
       }
     },
     {

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -1,27 +1,32 @@
-import { IncomingMessage } from 'http'
-import { PublishPacket, SubscribePacket, Subscription, Subscriptions, UnsubscribePacket } from './packet'
-import { Connection } from './instance'
-import { EventEmitter } from 'events'
+declare module 'client' {
+  import { IncomingMessage } from 'node:http'
+  import { PublishPacket, SubscribePacket, Subscription, Subscriptions, UnsubscribePacket } from 'aedes:packet'
+  import { Connection } from 'aedes:server'
+  import { EventEmitter } from 'node:events'
 
-export interface Client extends EventEmitter {
-  id: Readonly<string>
-  clean: Readonly<boolean>
-  version: Readonly<number>
-  conn: Connection
-  req?: IncomingMessage
-  connecting: Readonly<boolean>
-  connected: Readonly<boolean>
-  closed: Readonly<boolean>
+  export interface Client extends EventEmitter {
+    id: Readonly<string>
+    clean: Readonly<boolean>
+    version: Readonly<number>
+    conn: Connection
+    req?: IncomingMessage
+    connecting: Readonly<boolean>
+    connected: Readonly<boolean>
+    closed: Readonly<boolean>
 
-  on (event: 'connected', listener: () => void): this
-  on (event: 'error', listener: (error: Error) => void): this
+    on (event: 'connected', listener: () => void): this
+    on (event: 'error', listener: (error: Error) => void): this
 
-  publish (message: PublishPacket, callback?: (error?: Error) => void): void
-  subscribe (
-    subscriptions: Subscriptions | Subscription | Subscription[] | SubscribePacket,
-    callback?: (error?: Error) => void
-  ): void
-  unsubscribe (topicObjects: Subscriptions | Subscription | Subscription[] | UnsubscribePacket, callback?: (error?: Error) => void): void
-  close (callback?: () => void): void
-  emptyOutgoingQueue (callback?: () => void): void
+    publish (message: PublishPacket, callback?: (error?: Error) => void): void
+    subscribe (
+      subscriptions: Subscriptions | Subscription | Subscription[] | SubscribePacket,
+      callback?: (error?: Error) => void
+    ): void
+    unsubscribe (topicObjects: Subscriptions | Subscription | Subscription[] | UnsubscribePacket, callback?: (error?: Error) => void): void
+    close (callback?: () => void): void
+    emptyOutgoingQueue (callback?: () => void): void
+  }
+}
+declare module 'aedes:client' {
+  export * from 'client'
 }

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -1,100 +1,100 @@
-import { Duplex } from 'stream'
-import { Socket } from 'net'
-import { Client } from './client'
-import type { AedesPublishPacket, ConnectPacket, ConnackPacket, Subscription, PingreqPacket, PublishPacket, PubrelPacket } from './packet'
-import { EventEmitter } from 'events'
+declare module 'aedes' {
+  import { Duplex } from 'node:stream'
+  import { Socket } from 'node:net'
+  import { Client } from 'aedes:client'
+  import type { AedesPublishPacket, ConnectPacket, ConnackPacket, Subscription, PingreqPacket, PublishPacket, PubrelPacket } from 'aedes:packet'
+  import { EventEmitter } from 'node:events'
 
-type LastHearthbeatTimestamp = Date;
+  type LastHearthbeatTimestamp = Date;
 
-export interface Brokers {
-  [brokerId: string]: LastHearthbeatTimestamp;
+  export interface Brokers {
+    [brokerId: string]: LastHearthbeatTimestamp;
+  }
+
+  export type Connection = Duplex | Socket
+
+  /* eslint no-unused-vars: 0 */
+  export const enum AuthErrorCode {
+    UNNACCEPTABLE_PROTOCOL = 1,
+    IDENTIFIER_REJECTED = 2,
+    SERVER_UNAVAILABLE = 3,
+    BAD_USERNAME_OR_PASSWORD = 4,
+    NOT_AUTHORIZED = 5
+  }
+
+  export type AuthenticateError = Error & { returnCode: AuthErrorCode }
+
+  type PreConnectHandler = (client: Client, packet: ConnectPacket, callback: (error: Error | null, success: boolean) => void) => void
+
+  type AuthenticateHandler = (
+    client: Client,
+    username: Readonly<string>,
+    password: Readonly<Buffer>,
+    done: (error: AuthenticateError | null, success: boolean | null) => void
+  ) => void
+
+  type AuthorizePublishHandler = (client: Client, packet: PublishPacket, callback: (error?: Error | null) => void) => void
+
+  type AuthorizeSubscribeHandler = (client: Client, subscription: Subscription, callback: (error: Error | null, subscription?: Subscription | null) => void) => void
+
+  type AuthorizeForwardHandler = (client: Client, packet: AedesPublishPacket) => AedesPublishPacket | null | void
+
+  type PublishedHandler = (packet: AedesPublishPacket, client: Client, callback: (error?: Error | null) => void) => void
+
+  export interface AedesOptions {
+    mq?: any
+    id?: string
+    persistence?: any
+    concurrency?: number
+    heartbeatInterval?: number
+    connectTimeout?: number
+    queueLimit?: number
+    maxClientsIdLength?: number
+    preConnect?: PreConnectHandler
+    authenticate?: AuthenticateHandler
+    authorizePublish?: AuthorizePublishHandler
+    authorizeSubscribe?: AuthorizeSubscribeHandler
+    authorizeForward?: AuthorizeForwardHandler
+    published?: PublishedHandler
+  }
+
+  export default class Aedes extends EventEmitter {
+    id: Readonly<string>
+    connectedClients: Readonly<number>
+    closed: Readonly<boolean>
+    brokers: Readonly<Brokers>
+
+    constructor(option?: AedesOptions)
+    handle: (stream: Connection) => Client
+
+    on (event: 'closed', listener: () => void): this
+    on (event: 'client' | 'clientReady' | 'clientDisconnect' | 'keepaliveTimeout', listener: (client: Client) => void): this
+    on (event: 'clientError' | 'connectionError', listener: (client: Client, error: Error) => void): this
+    on (event: 'connackSent', listener: (packet: ConnackPacket, client: Client) => void): this
+    on (event: 'ping', listener: (packet: PingreqPacket, client: Client) => void): this
+    on (event: 'publish', listener: (packet: AedesPublishPacket, client: Client | null) => void): this
+    on (event: 'ack', listener: (packet: PublishPacket | PubrelPacket, client: Client) => void): this
+    on (event: 'subscribe', listener: (subscriptions: Subscription[], client: Client) => void): this
+    on (event: 'unsubscribe', listener: (unsubscriptions: string[], client: Client) => void): this
+
+    publish (packet: PublishPacket, callback: (error?: Error) => void): void
+    subscribe (topic: string, deliverfunc: (packet: AedesPublishPacket, callback: () => void) => void, callback: () => void): void
+    unsubscribe (topic: string, deliverfunc: (packet: AedesPublishPacket, callback: () => void) => void, callback: () => void): void
+    close (callback?: () => void): void
+
+    preConnect: PreConnectHandler
+    authenticate: AuthenticateHandler
+    authorizePublish: AuthorizePublishHandler
+    authorizeSubscribe: AuthorizeSubscribeHandler
+    authorizeForward: AuthorizeForwardHandler
+    published: PublishedHandler
+  }
+
+  export { Aedes }
+  // export function createServer(options?: AedesOptions): Aedes
 }
 
-export type Connection = Duplex | Socket
-
-/* eslint no-unused-vars: 0 */
-export const enum AuthErrorCode {
-  UNNACCEPTABLE_PROTOCOL = 1,
-  IDENTIFIER_REJECTED = 2,
-  SERVER_UNAVAILABLE = 3,
-  BAD_USERNAME_OR_PASSWORD = 4,
-  NOT_AUTHORIZED = 5
-}
-
-export type AuthenticateError = Error & { returnCode: AuthErrorCode }
-
-type PreConnectHandler = (client: Client, packet: ConnectPacket, callback: (error: Error | null, success: boolean) => void) => void
-
-type AuthenticateHandler = (
-  client: Client,
-  username: Readonly<string>,
-  password: Readonly<Buffer>,
-  done: (error: AuthenticateError | null, success: boolean | null) => void
-) => void
-
-type AuthorizePublishHandler = (client: Client, packet: PublishPacket, callback: (error?: Error | null) => void) => void
-
-type AuthorizeSubscribeHandler = (client: Client, subscription: Subscription, callback: (error: Error | null, subscription?: Subscription | null) => void) => void
-
-type AuthorizeForwardHandler = (client: Client, packet: AedesPublishPacket) => AedesPublishPacket | null | void
-
-type PublishedHandler = (packet: AedesPublishPacket, client: Client, callback: (error?: Error | null) => void) => void
-
-export interface AedesOptions {
-  mq?: any
-  id?: string
-  persistence?: any
-  concurrency?: number
-  heartbeatInterval?: number
-  connectTimeout?: number
-  queueLimit?: number
-  maxClientsIdLength?: number
-  preConnect?: PreConnectHandler
-  authenticate?: AuthenticateHandler
-  authorizePublish?: AuthorizePublishHandler
-  authorizeSubscribe?: AuthorizeSubscribeHandler
-  authorizeForward?: AuthorizeForwardHandler
-  published?: PublishedHandler
-}
-
-export interface Aedes extends EventEmitter {
-  id: Readonly<string>
-  connectedClients: Readonly<number>
-  closed: Readonly<boolean>
-  brokers: Readonly<Brokers>
-
-  handle: (stream: Connection) => Client
-
-  on (event: 'closed', listener: () => void): this
-  on (event: 'client' | 'clientReady' | 'clientDisconnect' | 'keepaliveTimeout', listener: (client: Client) => void): this
-  on (event: 'clientError' | 'connectionError', listener: (client: Client, error: Error) => void): this
-  on (event: 'connackSent', listener: (packet: ConnackPacket, client: Client) => void): this
-  on (event: 'ping', listener: (packet: PingreqPacket, client: Client) => void): this
-  on (event: 'publish', listener: (packet: AedesPublishPacket, client: Client | null) => void): this
-  on (event: 'ack', listener: (packet: PublishPacket | PubrelPacket, client: Client) => void): this
-  on (event: 'subscribe', listener: (subscriptions: Subscription[], client: Client) => void): this
-  on (event: 'unsubscribe', listener: (unsubscriptions: string[], client: Client) => void): this
-
-  publish (
-    packet: PublishPacket,
-    callback: (error?: Error) => void
-  ): void
-  subscribe (
-    topic: string,
-    deliverfunc: (packet: AedesPublishPacket, callback: () => void) => void,
-    callback: () => void
-  ): void
-  unsubscribe (
-    topic: string,
-    deliverfunc: (packet: AedesPublishPacket, callback: () => void) => void,
-    callback: () => void
-  ): void
-  close (callback?: () => void): void
-
-  preConnect: PreConnectHandler
-  authenticate: AuthenticateHandler
-  authorizePublish: AuthorizePublishHandler
-  authorizeSubscribe: AuthorizeSubscribeHandler
-  authorizeForward: AuthorizeForwardHandler
-  published: PublishedHandler
+declare module 'aedes:server' {
+  export * from 'aedes'
+  export { default } from 'aedes'
 }

--- a/types/packet.d.ts
+++ b/types/packet.d.ts
@@ -1,18 +1,23 @@
-import { AedesPacket } from 'aedes-packet'
-import { IConnackPacket, IConnectPacket, IPingreqPacket, IPublishPacket, IPubrelPacket, ISubscribePacket, ISubscription, IUnsubscribePacket } from 'mqtt-packet'
-import { Client } from './client'
+declare module 'packet' {
+  import { AedesPacket } from 'aedes-packet'
+  import { IConnackPacket, IConnectPacket, IPingreqPacket, IPublishPacket, IPubrelPacket, ISubscribePacket, ISubscription, IUnsubscribePacket } from 'mqtt-packet'
+  import { Client } from 'aedes:client'
 
-export type SubscribePacket = ISubscribePacket & { cmd: 'subscribe' }
-export type UnsubscribePacket = IUnsubscribePacket & { cmd: 'unsubscribe' }
-export type Subscription = ISubscription & { clientId?: Client['id'] }
-export type Subscriptions = { subscriptions: Subscription[] }
+  export type SubscribePacket = ISubscribePacket & { cmd: 'subscribe' }
+  export type UnsubscribePacket = IUnsubscribePacket & { cmd: 'unsubscribe' }
+  export type Subscription = ISubscription & { clientId?: Client['id'] }
+  export type Subscriptions = { subscriptions: Subscription[] }
 
-export type PublishPacket = IPublishPacket & { cmd: 'publish' }
+  export type PublishPacket = IPublishPacket & { cmd: 'publish' }
 
-export type ConnectPacket = IConnectPacket & { cmd: 'connect' }
-export type ConnackPacket = IConnackPacket & { cmd: 'connack' }
+  export type ConnectPacket = IConnectPacket & { cmd: 'connect' }
+  export type ConnackPacket = IConnackPacket & { cmd: 'connack' }
 
-export type PubrelPacket = IPubrelPacket & { cmd: 'pubrel' }
-export type PingreqPacket = IPingreqPacket & { cmd: 'pingreq' }
+  export type PubrelPacket = IPubrelPacket & { cmd: 'pubrel' }
+  export type PingreqPacket = IPingreqPacket & { cmd: 'pingreq' }
 
-export type AedesPublishPacket = PublishPacket & AedesPacket
+  export type AedesPublishPacket = PublishPacket & AedesPacket
+}
+declare module 'aedes:packet' {
+  export * from 'packet'
+}

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,13 +1,15 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
     "target": "es6",
+    "module": "commonjs",
     "noEmit": true,
-    "strict": true
+    "strict": true,
+    "removeComments": true,
+    "typeRoots" : ["../types", "../node_modules/@types/"]
   },
   "include": [
-    "/test/types/*.test-d.ts",
-    "/types/*.d.ts",
+    "./test/types/*.test-d.ts",
+    "./types/*.d.ts",
     "aedes.d.ts"
   ]
 }


### PR DESCRIPTION
A breaking change in TS
- drop Server() and Aedes() ts export functions
- add a prefix in aedes modules 

Sample usage
``` js
import Server, { Aedes } from 'aedes:server'
// the above is same as below
// import Server, { Aedes } from 'aedes'

let broker = new Server()
broker = new Aedes()
```