### PR TITLE
fix: authorize old wills

### DIFF
--- a/aedes.js
+++ b/aedes.js
@@ -115,27 +115,25 @@ function Aedes (opts) {
   }
 
   function checkAndPublish (will, done) {
-    const needsPublishing =
-      !that.brokers[will.brokerId] ||
-      that.brokers[will.brokerId] + (3 * opts.heartbeatInterval) <
-      Date.now()
+    const notPublish =
+      that.brokers[will.brokerId] !== undefined && that.brokers[will.brokerId] + (3 * opts.heartbeatInterval) >= Date.now()
 
-    if (needsPublishing) {
-      // randomize this, so that multiple brokers
-      // do not publish the same wills at the same time
-      that.publish(will, function publishWill (err) {
-        if (err) {
-          return done(err)
-        }
+    if (notPublish) return done()
 
+    // randomize this, so that multiple brokers
+    // do not publish the same wills at the same time
+    this.authorizePublish(that.clients[will.clientId] || null, will, function (err) {
+      if (err) { return doneWill() }
+      that.publish(will, doneWill)
+
+      function doneWill (err) {
+        if (err) { return done(err) }
         that.persistence.delWill({
           id: will.clientId,
           brokerId: will.brokerId
         }, done)
-      })
-    } else {
-      done()
-    }
+      }
+    })
   }
 
   this.mq.on($SYS_PREFIX + '+/heartbeat', function storeBroker (packet, done) {

--- a/docs/Aedes.md
+++ b/docs/Aedes.md
@@ -291,7 +291,7 @@ Please refer to [Connect Return Code](http://docs.oasis-open.org/mqtt/mqtt/v3.1.
 
 ## Handler: authorizePublish (client, packet, callback)
 
-- client: [`<Client>`](./Client.md)
+- client: [`<Client>`](./Client.md) | `null`
 - packet: `<object>` [`PUBLISH`][PUBLISH]
 - callback: `<Function>` `(error) => void`
   - error `<Error>` | `null`
@@ -300,6 +300,8 @@ Invoked when
 
 1. publish LWT to all online clients
 2. incoming client publish
+
+`client` is `null` when aedes publishes obsolete LWT without connected clients
 
 If invoked `callback` with no errors, server authorizes the packet otherwise emits `clientError` with `error`. If an `error` occurs the client connection will be closed, but no error is returned to the client (MQTT-3.3.5-2)
 

--- a/test/types/aedes.test-d.ts
+++ b/test/types/aedes.test-d.ts
@@ -38,7 +38,7 @@ broker = new Aedes({
       callback(error, false)
     }
   },
-  authorizePublish: (client: Client, packet: PublishPacket, callback) => {
+  authorizePublish: (client: Client | null, packet: PublishPacket, callback) => {
     if (packet.topic === 'aaaa') {
       return callback(new Error('wrong topic'))
     }

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -33,7 +33,7 @@ declare module 'aedes' {
     done: (error: AuthenticateError | null, success: boolean | null) => void
   ) => void
 
-  type AuthorizePublishHandler = (client: Client, packet: PublishPacket, callback: (error?: Error | null) => void) => void
+  type AuthorizePublishHandler = (client: Client | null, packet: PublishPacket, callback: (error?: Error | null) => void) => void
 
   type AuthorizeSubscribeHandler = (client: Client, subscription: Subscription, callback: (error: Error | null, subscription?: Subscription | null) => void) => void
 


### PR DESCRIPTION
This is a response to #767, to authorise old wills be published. The `client` will be `null` in `authorizePublish` in this case.