### PR TITLE
fix(types): `aedes.handle` type definition

### DIFF
--- a/test/types/aedes.test-d.ts
+++ b/test/types/aedes.test-d.ts
@@ -4,6 +4,7 @@ import type { AedesPublishPacket, ConnackPacket, ConnectPacket, PingreqPacket, P
 import type { AuthenticateError, Brokers, Connection } from 'aedes:server'
 import Server, { Aedes } from 'aedes:server'
 
+import { IncomingMessage } from 'node:http'
 import type { Client } from 'aedes:client'
 import { Socket } from 'node:net'
 import { expectType } from 'tsd'
@@ -124,11 +125,12 @@ expectType<void>(broker.close())
 expectType<void>(broker.close(() => {}))
 
 // Aedes client
-const client = broker.handle({} as Connection)
+const client = broker.handle({} as Connection, {} as IncomingMessage)
 
 expectType<Client>(client)
 
 expectType<Connection>(client.conn)
+expectType<IncomingMessage>(client.req!)
 
 expectType<Client>(client.on('connected', () => {}))
 expectType<Client>(client.on('error', (error: Error) => {

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -66,7 +66,7 @@ declare module 'aedes' {
     brokers: Readonly<Brokers>
 
     constructor(option?: AedesOptions)
-    handle: (stream: Connection, request: IncomingMessage ) => Client
+    handle: (stream: Connection, request: IncomingMessage) => Client
 
     on (event: 'closed', listener: () => void): this
     on (event: 'client' | 'clientReady' | 'clientDisconnect' | 'keepaliveTimeout', listener: (client: Client) => void): this

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -1,6 +1,7 @@
 declare module 'aedes' {
   import { Duplex } from 'node:stream'
   import { Socket } from 'node:net'
+  import { IncomingMessage } from 'http'
   import { Client } from 'aedes:client'
   import type { AedesPublishPacket, ConnectPacket, ConnackPacket, Subscription, PingreqPacket, PublishPacket, PubrelPacket } from 'aedes:packet'
   import { EventEmitter } from 'node:events'
@@ -65,7 +66,7 @@ declare module 'aedes' {
     brokers: Readonly<Brokers>
 
     constructor(option?: AedesOptions)
-    handle: (stream: Connection) => Client
+    handle: (stream: Connection, request: IncomingMessage ) => Client
 
     on (event: 'closed', listener: () => void): this
     on (event: 'client' | 'clientReady' | 'clientDisconnect' | 'keepaliveTimeout', listener: (client: Client) => void): this


### PR DESCRIPTION
Add missing type parameter of `request: IncomingMessage` on `aedes.handle` method.

[aedes.js#L55](https://github.com/moscajs/aedes/blob/main/aedes.js#L55)
```ts
...
    matchEmptyLevels: true // [MQTT-4.7.1-3]
  })
  this.handle = function handle (conn, req) {
    conn.setMaxListeners(opts.concurrency * 2)
    // create a new Client instance for a new connection
    // return, just to please standard
...
```