### PR TITLE
fix(types): update username and password type definition

### DIFF
--- a/test/types/aedes.test-d.ts
+++ b/test/types/aedes.test-d.ts
@@ -29,7 +29,7 @@ broker = new Aedes({
       callback(new Error('connection error'), false)
     }
   },
-  authenticate: (client: Client, username: Readonly<string>, password: Readonly<Buffer>, callback) => {
+  authenticate: (client: Client, username: Readonly<string | undefined>, password: Readonly<Buffer | undefined>, callback) => {
     if (username === 'test' && password === Buffer.from('test') && client.version === 4) {
       callback(null, true)
     } else {
@@ -86,19 +86,19 @@ expectType<Aedes>(broker)
 
 expectType<Readonly<Brokers>>(broker.brokers)
 
-expectType<Aedes>(broker.on('closed', () => {}))
-expectType<Aedes>(broker.on('client', (client: Client) => {}))
-expectType<Aedes>(broker.on('clientReady', (client: Client) => {}))
-expectType<Aedes>(broker.on('clientDisconnect', (client: Client) => {}))
-expectType<Aedes>(broker.on('keepaliveTimeout', (client: Client) => {}))
-expectType<Aedes>(broker.on('clientError', (client: Client, error: Error) => {}))
-expectType<Aedes>(broker.on('connectionError', (client: Client, error: Error) => {}))
-expectType<Aedes>(broker.on('connackSent', (packet: ConnackPacket, client: Client) => {}))
-expectType<Aedes>(broker.on('ping', (packet: PingreqPacket, client: Client) => {}))
-expectType<Aedes>(broker.on('publish', (packet: AedesPublishPacket, client: Client | null) => {}))
-expectType<Aedes>(broker.on('ack', (packet: PublishPacket | PubrelPacket, client: Client) => {}))
-expectType<Aedes>(broker.on('subscribe', (subscriptions: Subscription[], client: Client) => {}))
-expectType<Aedes>(broker.on('unsubscribe', (unsubscriptions: string[], client: Client) => {}))
+expectType<Aedes>(broker.on('closed', () => { }))
+expectType<Aedes>(broker.on('client', (client: Client) => { }))
+expectType<Aedes>(broker.on('clientReady', (client: Client) => { }))
+expectType<Aedes>(broker.on('clientDisconnect', (client: Client) => { }))
+expectType<Aedes>(broker.on('keepaliveTimeout', (client: Client) => { }))
+expectType<Aedes>(broker.on('clientError', (client: Client, error: Error) => { }))
+expectType<Aedes>(broker.on('connectionError', (client: Client, error: Error) => { }))
+expectType<Aedes>(broker.on('connackSent', (packet: ConnackPacket, client: Client) => { }))
+expectType<Aedes>(broker.on('ping', (packet: PingreqPacket, client: Client) => { }))
+expectType<Aedes>(broker.on('publish', (packet: AedesPublishPacket, client: Client | null) => { }))
+expectType<Aedes>(broker.on('ack', (packet: PublishPacket | PubrelPacket, client: Client) => { }))
+expectType<Aedes>(broker.on('subscribe', (subscriptions: Subscription[], client: Client) => { }))
+expectType<Aedes>(broker.on('unsubscribe', (unsubscriptions: string[], client: Client) => { }))
 
 expectType<void>(broker.publish(
   {} as PublishPacket,
@@ -111,18 +111,18 @@ expectType<void>(broker.publish(
 
 expectType<void>(broker.subscribe(
   'topic',
-  (packet: AedesPublishPacket, callback: () => void) => {},
-  () => {}
+  (packet: AedesPublishPacket, callback: () => void) => { },
+  () => { }
 ))
 
 expectType<void>(broker.unsubscribe(
   'topic',
-  (packet: AedesPublishPacket, callback: () => void) => {},
-  () => {}
+  (packet: AedesPublishPacket, callback: () => void) => { },
+  () => { }
 ))
 
 expectType<void>(broker.close())
-expectType<void>(broker.close(() => {}))
+expectType<void>(broker.close(() => { }))
 
 // Aedes client
 const client = broker.handle({} as Connection, {} as IncomingMessage)
@@ -132,7 +132,7 @@ expectType<Client>(client)
 expectType<Connection>(client.conn)
 expectType<IncomingMessage>(client.req!)
 
-expectType<Client>(client.on('connected', () => {}))
+expectType<Client>(client.on('connected', () => { }))
 expectType<Client>(client.on('error', (error: Error) => {
   if (error) {
     console.error(error)
@@ -165,7 +165,7 @@ expectType<void>(client.unsubscribe([] as Subscription[]))
 expectType<void>(client.unsubscribe({} as UnsubscribePacket))
 
 expectType<void>(client.emptyOutgoingQueue())
-expectType<void>(client.emptyOutgoingQueue(() => {}))
+expectType<void>(client.emptyOutgoingQueue(() => { }))
 
 expectType<void>(client.close())
-expectType<void>(client.close(() => {}))
+expectType<void>(client.close(() => { }))

--- a/test/types/aedes.test-d.ts
+++ b/test/types/aedes.test-d.ts
@@ -86,19 +86,19 @@ expectType<Aedes>(broker)
 
 expectType<Readonly<Brokers>>(broker.brokers)
 
-expectType<Aedes>(broker.on('closed', () => { }))
-expectType<Aedes>(broker.on('client', (client: Client) => { }))
-expectType<Aedes>(broker.on('clientReady', (client: Client) => { }))
-expectType<Aedes>(broker.on('clientDisconnect', (client: Client) => { }))
-expectType<Aedes>(broker.on('keepaliveTimeout', (client: Client) => { }))
-expectType<Aedes>(broker.on('clientError', (client: Client, error: Error) => { }))
-expectType<Aedes>(broker.on('connectionError', (client: Client, error: Error) => { }))
-expectType<Aedes>(broker.on('connackSent', (packet: ConnackPacket, client: Client) => { }))
-expectType<Aedes>(broker.on('ping', (packet: PingreqPacket, client: Client) => { }))
-expectType<Aedes>(broker.on('publish', (packet: AedesPublishPacket, client: Client | null) => { }))
-expectType<Aedes>(broker.on('ack', (packet: PublishPacket | PubrelPacket, client: Client) => { }))
-expectType<Aedes>(broker.on('subscribe', (subscriptions: Subscription[], client: Client) => { }))
-expectType<Aedes>(broker.on('unsubscribe', (unsubscriptions: string[], client: Client) => { }))
+expectType<Aedes>(broker.on('closed', () => {}))
+expectType<Aedes>(broker.on('client', (client: Client) => {}))
+expectType<Aedes>(broker.on('clientReady', (client: Client) => {}))
+expectType<Aedes>(broker.on('clientDisconnect', (client: Client) => {}))
+expectType<Aedes>(broker.on('keepaliveTimeout', (client: Client) => {}))
+expectType<Aedes>(broker.on('clientError', (client: Client, error: Error) => {}))
+expectType<Aedes>(broker.on('connectionError', (client: Client, error: Error) => {}))
+expectType<Aedes>(broker.on('connackSent', (packet: ConnackPacket, client: Client) => {}))
+expectType<Aedes>(broker.on('ping', (packet: PingreqPacket, client: Client) => {}))
+expectType<Aedes>(broker.on('publish', (packet: AedesPublishPacket, client: Client | null) => {}))
+expectType<Aedes>(broker.on('ack', (packet: PublishPacket | PubrelPacket, client: Client) => {}))
+expectType<Aedes>(broker.on('subscribe', (subscriptions: Subscription[], client: Client) => {}))
+expectType<Aedes>(broker.on('unsubscribe', (unsubscriptions: string[], client: Client) => {}))
 
 expectType<void>(broker.publish(
   {} as PublishPacket,
@@ -111,18 +111,18 @@ expectType<void>(broker.publish(
 
 expectType<void>(broker.subscribe(
   'topic',
-  (packet: AedesPublishPacket, callback: () => void) => { },
-  () => { }
+  (packet: AedesPublishPacket, callback: () => void) => {},
+  () => {}
 ))
 
 expectType<void>(broker.unsubscribe(
   'topic',
-  (packet: AedesPublishPacket, callback: () => void) => { },
-  () => { }
+  (packet: AedesPublishPacket, callback: () => void) => {},
+  () => {}
 ))
 
 expectType<void>(broker.close())
-expectType<void>(broker.close(() => { }))
+expectType<void>(broker.close(() => {}))
 
 // Aedes client
 const client = broker.handle({} as Connection, {} as IncomingMessage)
@@ -132,7 +132,7 @@ expectType<Client>(client)
 expectType<Connection>(client.conn)
 expectType<IncomingMessage>(client.req!)
 
-expectType<Client>(client.on('connected', () => { }))
+expectType<Client>(client.on('connected', () => {}))
 expectType<Client>(client.on('error', (error: Error) => {
   if (error) {
     console.error(error)
@@ -165,7 +165,7 @@ expectType<void>(client.unsubscribe([] as Subscription[]))
 expectType<void>(client.unsubscribe({} as UnsubscribePacket))
 
 expectType<void>(client.emptyOutgoingQueue())
-expectType<void>(client.emptyOutgoingQueue(() => { }))
+expectType<void>(client.emptyOutgoingQueue(() => {}))
 
 expectType<void>(client.close())
-expectType<void>(client.close(() => { }))
+expectType<void>(client.close(() => {}))

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -29,7 +29,7 @@ declare module 'aedes' {
 
   type AuthenticateHandler = (
     client: Client,
-    username: Readonly<string>,
+    username?: Readonly<string>,
     password?: Readonly<Buffer>,
     done: (error: AuthenticateError | null, success: boolean | null) => void
   ) => void

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -29,8 +29,8 @@ declare module 'aedes' {
 
   type AuthenticateHandler = (
     client: Client,
-    username?: Readonly<string>,
-    password?: Readonly<Buffer>,
+    username: Readonly<string | undefined>,
+    password: Readonly<Buffer | undefined>,
     done: (error: AuthenticateError | null, success: boolean | null) => void
   ) => void
 

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -30,7 +30,7 @@ declare module 'aedes' {
   type AuthenticateHandler = (
     client: Client,
     username: Readonly<string>,
-    password: Readonly<Buffer>,
+    password?: Readonly<Buffer>,
     done: (error: AuthenticateError | null, success: boolean | null) => void
   ) => void
 


### PR DESCRIPTION
The username and password variables have the undefined type when not set in the MQTTX client.