### PR TITLE
Fix module exports for TypeScript for ES6 compliance.

### DIFF
--- a/aedes.d.ts
+++ b/aedes.d.ts
@@ -1,12 +1,5 @@
-import Aedes, { AedesOptions } from './types/instance'
+export * from './types/instance';
+export * from './types/packet';
+export * from './types/client';
 
-export declare function createBroker (options?: AedesOptions): Aedes
-
-export * from './types/instance'
-export * from './types/packet'
-export * from './types/client'
-export default Aedes
-
-declare module 'aedes' {
-  export = Aedes
-}
+export { default } from './types/instance';


### PR DESCRIPTION
Addresses https://github.com/moscajs/aedes/issues/878#issuecomment-1825783310 and corrects the export declaration in TypeScript.
