### PR TITLE
fix: delete will from persistence on disconnect

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -313,7 +313,14 @@ Client.prototype.close = function (done) {
           }, noop)
         }
       })
+    } else if (will) {
+      // delete the persisted will even on clean disconnect
+      that.broker.persistence.delWill({
+        id: that.id,
+        brokerId: that.broker.id
+      }, noop)
     }
+
     that.will = null // this function might be called twice
     that._will = null
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -314,7 +314,7 @@ Client.prototype.close = function (done) {
         }
       })
     } else if (will) {
-      // delete the persisted will even on clean disconnect
+      // delete the persisted will even on clean disconnect https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc385349232
       that.broker.persistence.delWill({
         id: that.id,
         brokerId: that.broker.id

--- a/test/will.js
+++ b/test/will.js
@@ -420,6 +420,29 @@ test('does not deliver will when client sends a DISCONNECT', function (t) {
   })
 })
 
+test('deletes from persistence on DISCONNECT', function (t) {
+  t.plan(2)
+
+  const opts = {
+    clientId: 'abcde'
+  }
+  const broker = aedes()
+  t.teardown(broker.close.bind(broker))
+
+  const s = noError(willConnect(setup(broker), opts, function () {
+    s.inStream.end({
+      cmd: 'disconnect'
+    })
+  }), t)
+
+  s.broker.persistence.getWill({
+    id: opts.clientId
+  }, function (err, packet) {
+    t.error(err, 'no error')
+    t.notOk(packet)
+  })
+})
+
 test('does not store multiple will with same clientid', function (t) {
   t.plan(4)
 


### PR DESCRIPTION
## Problem 
I was using aedes-persistence-redis and noticed that if clients connect with a will message then the keys weren't being deleted on a clean disconnect

## Solution
The keys should always be removed from the persistence regardless if the the client disconnects cleanly or not.  When the client disconnects, the will no longer should matter so we can delete it. If the client connects again with another will, then we can retain that one. 