### PR TITLE
fix: #955 - Updated dedupe to check history of sent packets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ node_modules
 .lock-wscript
 .vscode
 *code-workspace
+.idea
 
 # 0x
 flamegraph.html

--- a/aedes.js
+++ b/aedes.js
@@ -30,7 +30,8 @@ const defaultOptions = {
   trustedProxies: [],
   queueLimit: 42,
   maxClientsIdLength: 23,
-  keepaliveLimit: 0
+  keepaliveLimit: 0,
+  dedupeLimit: 100
 }
 
 function Aedes (opts) {
@@ -47,6 +48,7 @@ function Aedes (opts) {
   // internal track for last brokerCounter
   this.counter = 0
   this.queueLimit = opts.queueLimit
+  this.dedupeLimit = opts.dedupeLimit
   this.connectTimeout = opts.connectTimeout
   this.keepaliveLimit = opts.keepaliveLimit
   this.maxClientsIdLength = opts.maxClientsIdLength

--- a/docs/Aedes.md
+++ b/docs/Aedes.md
@@ -43,6 +43,7 @@
   - `id` `<string>` aedes broker unique identifier. __Default__: `uuidv4()`
   - `connectTimeout` `<number>` maximum waiting time in milliseconds waiting for a [`CONNECT`][CONNECT] packet. __Default__: `30000`
   - `keepaliveLimit` `<number>` maximum client keep alive time allowed, 0 means no limit. __Default__: `0`
+  - `dedupeLimit` `<number>` the maximum number of packets that are checked for duplication. This is used to prevent the broker from resending the same packet multiple times. __Default__: `100`
 - Returns `<Aedes>`
 
 Create a new Aedes server.

--- a/lib/client.js
+++ b/lib/client.js
@@ -167,11 +167,24 @@ function dedupe (client, packet) {
   }
   const duplicates = client.duplicates
   const counter = packet.brokerCounter
-  const result = (duplicates[id] || 0) < counter
-  if (result) {
-    duplicates[id] = counter
+
+  if (!duplicates[id]) {
+    duplicates[id] = { seen: new Set(), order: [] }
   }
-  return result
+
+  const entry = duplicates[id]
+  if (entry.seen.has(counter)) {
+    return false
+  }
+
+  entry.seen.add(counter)
+  entry.order.push(counter)
+
+  if (entry.order.length > client.broker.dedupeLimit) {
+    const oldest = entry.order.shift()
+    entry.seen.delete(oldest)
+  }
+  return true
 }
 
 function writeQoS (err, client, packet) {

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -78,6 +78,7 @@ export interface AedesOptions {
   keepaliveLimit?: number;
   queueLimit?: number;
   maxClientsIdLength?: number;
+  dedupeLimit?: number;
   preConnect?: PreConnectHandler;
   authenticate?: AuthenticateHandler;
   authorizePublish?: AuthorizePublishHandler;


### PR DESCRIPTION
Updated the dedupe function to checks if a packet has already been seen before, based on the packet's broker ID and counter. If the packet is a duplicate (already seen before), it is not forwarded again. The temporary list for dedupe is configurable as part of the init options, defaults to 100.

This bug occurs with a mongoDB persistence configuration and have not been able to reproduce with a default persistence settings.  
