### PR TITLE
chore: add type commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.51.3",
   "description": "Stream-based MQTT broker",
   "main": "aedes.js",
+  "type": "commonjs",
   "types": "aedes.d.ts",
   "scripts": {
     "lint": "npm run lint:standard && npm run lint:typescript && npm run lint:markdown",


### PR DESCRIPTION
Followed the guideline in the [ESM](https://nodejs.org/api/esm.html#esm_package_json_type_field), we explicitly state module type.