### PR TITLE
chore: migrate websocket-stream to ws

### DIFF
--- a/docs/Client.md
+++ b/docs/Client.md
@@ -34,13 +34,13 @@ Client connection stream object.
 
 In the case of `net.createServer`, `conn` passed to the `connectionlistener` function by node's [net.createServer](https://nodejs.org/api/net.html#net_net_createserver_options_connectionlistener) API.
 
-In the case of [`websocket-stream`][websocket-stream], it's the `stream` argument passed to the websocket `handle` function in [`websocket-stream #on-the-server`][websocket-stream-doc-on-the-server]].
+In the case of [`ws`][ws], it's the `stream.Duplex` argument passed to the `handle` function.
 
 ## client.req
 
 - `<http.IncomingMessage>`
 
-only for [`websocket-stream`][websocket-stream]. It is a HTTP Websocket upgrade request object passed to websocket `handle` function in [`websocket-stream #on-the-server`][websocket-stream-doc-on-the-server]. It gives an option for accessing headers or cookies.
+only for [`ws`][ws]. It is a HTTP Websocket upgrade request object passed to the `handle` function. It gives an option for accessing headers or cookies.
 
 ## client.connecting
 
@@ -152,5 +152,4 @@ Clear all outgoing messages (QoS > 1) related to this client from persistence
 [SUBSCRIBE]: https://github.com/mqttjs/mqtt-packet#subscribe
 [UNSUBSCRIBE]: https://github.com/mqttjs/mqtt-packet#unsubscribe
 
-[websocket-stream]: https://www.npmjs.com/websocket-stream
-[websocket-stream-doc-on-the-server]: https://github.com/maxogden/websocket-stream/blob/master/readme.md#on-the-server
+[ws]: https://www.npmjs.com/package/ws

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -67,10 +67,17 @@ server.listen(port, function () {
 ```js
 const aedes = require('aedes')()
 const httpServer = require('http').createServer()
-const ws = require('websocket-stream')
+const ws = require('ws')
 const port = 8888
 
-ws.createServer({ server: httpServer }, aedes.handle)
+const wss = new ws.WebSocketServer({
+  server:httpServer
+})
+
+wss.on('connection', (websocket, req) => {
+  const stream = ws.createWebSocketStream(websocket)
+  aedes.handle(stream, req)
+})
 
 httpServer.listen(port, function () {
   console.log('websocket server listening on port ', port)

--- a/example.js
+++ b/example.js
@@ -3,7 +3,7 @@
 const aedes = require('./aedes')()
 const server = require('net').createServer(aedes.handle)
 const httpServer = require('http').createServer()
-const ws = require('websocket-stream')
+const ws = require('ws')
 const port = 1883
 const wsPort = 8888
 
@@ -11,9 +11,14 @@ server.listen(port, function () {
   console.log('server listening on port', port)
 })
 
-ws.createServer({
-  server: httpServer
-}, aedes.handle)
+const wss = new ws.WebSocketServer({
+  server
+})
+
+wss.on('connection', (websocket, req) => {
+  const stream = ws.createWebSocketStream(websocket)
+  aedes.handle(stream, req)
+})
 
 httpServer.listen(wsPort, function () {
   console.log('websocket server listening on port', wsPort)

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "tap": "^16.3.10",
     "tsd": "^0.32.0",
     "typescript": "^5.8.3",
-    "websocket-stream": "^5.5.2"
+    "ws": "^8.18.2"
   },
   "dependencies": {
     "aedes-packet": "^3.0.0",


### PR DESCRIPTION
This PR migrates Aedes from websocket-stream to ws.
When installing npm modules I got warnings from npm on high-severity issues on websocket stream.

In the discussion at https://github.com/max-mapper/websocket-stream/pull/166 it became clear that the best way forward is to migrate from websocket-stream to ws.

Aedes only used websocket-stream in test but the documentation recommended to use it as well.

I have a question open at ws to see if we can improve the developer experience when setting up a websocket stream, but for now we have a working setup and the documentation has been amended.

KInd regards,
Hans
