### PR TITLE
chore:  update aedes-persistence to 10.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
   },
   "dependencies": {
     "aedes-packet": "^3.0.0",
-    "aedes-persistence": "^9.1.2",
+    "aedes-persistence": "^10.2.0",
     "end-of-stream": "^1.4.5",
     "fastfall": "^1.5.1",
     "fastparallel": "^2.4.1",

--- a/test/client-pub-sub.js
+++ b/test/client-pub-sub.js
@@ -808,24 +808,28 @@ test('get message when client connects', function (t) {
   t.plan(2)
 
   const client1 = 'gav'
+  const client2 = 'friend'
   const broker = aedes()
   t.teardown(broker.close.bind(broker))
 
   broker.on('client', function (client) {
-    client.subscribe({
-      subscriptions: [{
-        topic: '$SYS/+/new/clients',
-        qos: 0
-      }]
-    }, function (err) {
-      t.error(err, 'no error')
-    })
+    if (client.id === client1) {
+      client.subscribe({
+        subscriptions: [{
+          topic: '$SYS/+/new/clients',
+          qos: 0
+        }]
+      }, function (err) {
+        t.error(err, 'no error')
+      })
+    }
   })
 
   const s1 = connect(setup(broker), { clientId: client1 })
+  connect(setup(broker), { clientId: client2 })
 
   s1.outStream.on('data', function (packet) {
-    t.equal(client1, packet.payload.toString())
+    t.equal(client2, packet.payload.toString())
   })
 })
 


### PR DESCRIPTION
This PR updates aedes-persistence to version 10.2.0

It does *not* yet use the async persistence interface!

However Aedes should work ok with the callback interface of 10.2.0
Installing version 10.2.0 highlighted a race condition in test/client-pub-sub.js where the client would subscribe to the announcement of its own connect. This is no problem with synchronous persistence, but since we now run async the client  misses its own connect announcement.

Kind regards,
Hans