### PR TITLE
feat: migrate to async persistence

### DIFF
--- a/aedes.js
+++ b/aedes.js
@@ -137,7 +137,7 @@ class Aedes extends EventEmitter {
           that.persistence.delWill({
             id: will.clientId,
             brokerId: will.brokerId
-          }, done)
+          }).then(will => done(undefined, will), done)
         }
       })
     }
@@ -263,7 +263,8 @@ class Aedes extends EventEmitter {
 
 function storeRetained (packet, done) {
   if (packet.retain) {
-    this.broker.persistence.storeRetained(packet, done)
+    this.broker.persistence.storeRetained(packet)
+      .then(() => done(null), done)
   } else {
     done()
   }
@@ -281,10 +282,8 @@ function enqueueOffline (packet, done) {
   enqueuer.packet = packet
   enqueuer.topic = packet.topic
   enqueuer.broker = this.broker
-  this.broker.persistence.subscriptionsByTopic(
-    packet.topic,
-    enqueuer.done
-  )
+  this.broker.persistence.subscriptionsByTopic(packet.topic)
+    .then(subs => enqueuer.done(null, subs), enqueuer.done)
 }
 
 class DoEnqueues {
@@ -319,7 +318,8 @@ class DoEnqueues {
       that.complete = null
       that.topic = null
 
-      broker.persistence.outgoingEnqueueCombi(subs, packet, complete)
+      broker.persistence.outgoingEnqueueCombi(subs, packet)
+        .then(() => complete(null), complete)
       broker._enqueuers.release(that)
     }
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -135,14 +135,17 @@ class Client {
             packet.qos = clientSub.qos
           }
           packet.writeCallback = cb
+          const doWriteQoS = (err = null) => writeQoS(err, that, packet)
           if (that.clean || packet.retain) {
-            writeQoS(null, that, packet)
+            doWriteQoS()
           } else {
-            broker.persistence.outgoingUpdate(that, packet, writeQoS)
+            broker.persistence.outgoingUpdate(that, packet)
+              .then(doWriteQoS, doWriteQoS)
           }
         })
       } else if (that.clean === false) {
-        that.broker.persistence.outgoingClearMessageId(that, _packet, noop)
+        that.broker.persistence.outgoingClearMessageId(that, _packet)
+          .then(noop, noop)
         // we consider this to be an error, since the packet is undefined
         // so there's nothing to send
         setImmediate(cb)
@@ -181,15 +184,10 @@ class Client {
       this.deliver0(packet, done)
       return
     }
+
     if (!this.clean && this.id) {
-      this.broker.persistence.outgoingEnqueue({
-        clientId: this.id
-      }, packet, function deliver (err) {
-        if (err) {
-          return done(err)
-        }
-        that.deliverQoS(packet, done)
-      })
+      this.broker.persistence.outgoingEnqueue({ clientId: this.id }, packet)
+        .then(() => that.deliverQoS(packet, done), done)
     } else {
       that.deliverQoS(packet, done)
     }
@@ -270,7 +268,7 @@ class Client {
             that.broker.persistence.delWill({
               id: that.id,
               brokerId: that.broker.id
-            }, noop)
+            }).then(noop, noop)
           }
         })
       } else if (will) {
@@ -278,7 +276,7 @@ class Client {
         that.broker.persistence.delWill({
           id: that.id,
           brokerId: that.broker.id
-        }, noop)
+        }).then(noop, noop)
       }
 
       that.will = null // this function might be called twice
@@ -320,7 +318,8 @@ class Client {
     const persistence = client.broker.persistence
 
     function filter (packet, enc, next) {
-      persistence.outgoingClearMessageId(client, packet, next)
+      persistence.outgoingClearMessageId(client, packet)
+        .then(pkt => next(null, pkt), next)
     }
 
     pipeline(

--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -163,24 +163,22 @@ function setKeepAlive (arg, done) {
 function fetchSubs (arg, done) {
   const client = this.client
   if (!this.packet.clean) {
-    client.broker.persistence.subscriptionsByClient({
+    const subsClient = {
       id: client.id,
       done,
       arg
-    }, gotSubs)
+    }
+    client.broker.persistence.subscriptionsByClient({ id: client.id })
+      .then(subs => gotSubs(subs, subsClient), subsClient.done)
     return
   }
   arg.sessionPresent = false // [MQTT-3.2.2-1]
-  client.broker.persistence.cleanSubscriptions(
-    client,
-    done)
+  client.broker.persistence.cleanSubscriptions(client)
+    .then(() => done(null), done)
 }
 
-function gotSubs (err, subs, client) {
-  if (err) {
-    return client.done(err)
-  }
-  client.arg.subs = subs
+function gotSubs (subs, client) {
+  client.arg.subs = subs.length > 0 ? subs : null
   client.done()
 }
 
@@ -198,16 +196,15 @@ function storeWill (arg, done) {
   const client = this.client
   client.will = client._will
   // delete any existing will messages from persistence
-  client.broker.persistence.delWill(client, function () {
-    if (client.will) {
-      client.broker.persistence.putWill(
-        client,
-        client.will,
-        done)
-    } else {
-      done()
-    }
-  })
+  client.broker.persistence.delWill(client)
+    .finally(() => {
+      if (client.will) {
+        client.broker.persistence.putWill(client, client.will)
+          .then(() => done(null, client), done)
+      } else {
+        done()
+      }
+    })
 }
 
 function registerClient (arg, done) {
@@ -246,7 +243,9 @@ function emptyQueue (arg, done) {
       // Object filled the buffer up to the highWaterMark preventing stored messages
       // being sent
       packet.writeCallback = (error, _client) => next(error)
-      persistence.outgoingUpdate(client, packet, emptyQueueFilter)
+      const filter = (err) => emptyQueueFilter(err, client, packet)
+      persistence.outgoingUpdate(client, packet)
+        .then(() => filter(null, client, packet), err => filter(err, client, packet))
     }),
     done
   )
@@ -267,7 +266,8 @@ function emptyQueueFilter (err, client, packet) {
   const persistence = client.broker.persistence
 
   if (client.clean || !authorized) {
-    persistence.outgoingClearMessageId(client, packet, next)
+    persistence.outgoingClearMessageId(client, packet)
+      .then(packet => next(null, packet), next)
   } else {
     write(client, packet, next)
   }

--- a/lib/handlers/puback.js
+++ b/lib/handlers/puback.js
@@ -2,10 +2,12 @@
 
 function handlePuback (client, packet, done) {
   const persistence = client.broker.persistence
-  persistence.outgoingClearMessageId(client, packet, function (err, origPacket) {
+  const emitAck = (err, origPacket) => {
     client.broker.emit('ack', origPacket, client)
     done(err)
-  })
+  }
+  persistence.outgoingClearMessageId(client, packet)
+    .then((packet) => emitAck(null, packet), emitAck)
 }
 
 module.exports = handlePuback

--- a/lib/handlers/publish.js
+++ b/lib/handlers/publish.js
@@ -43,10 +43,8 @@ function enqueuePublish (packet, done) {
 
   switch (packet.qos) {
     case 2:
-      client.broker.persistence.incomingStorePacket(client, packet, function (err) {
-        if (err) { return done(err) }
-        write(client, new PubRec(packet), done)
-      })
+      client.broker.persistence.incomingStorePacket(client, packet)
+        .then(() => write(client, new PubRec(packet), done), done)
       break
     case 1:
       write(client, new PubAck(packet), function (err) {

--- a/lib/handlers/pubrec.js
+++ b/lib/handlers/pubrec.js
@@ -17,16 +17,8 @@ function handlePubrec (client, packet, done) {
     return
   }
 
-  client.broker.persistence.outgoingUpdate(
-    client, pubrel, reply)
-
-  function reply (err) {
-    if (err) {
-      done(err)
-    } else {
-      write(client, pubrel, done)
-    }
-  }
+  client.broker.persistence.outgoingUpdate(client, pubrel)
+    .then(() => write(client, pubrel, done), done)
 }
 
 module.exports = handlePubrec

--- a/lib/handlers/pubrel.js
+++ b/lib/handlers/pubrel.js
@@ -30,7 +30,8 @@ function handlePubrel (client, packet, done) {
 
 function pubrelGet (arg, done) {
   const persistence = this.client.broker.persistence
-  persistence.incomingGetPacket(this.client, this.packet, reply)
+  persistence.incomingGetPacket(this.client, this.packet)
+    .then((packet) => reply(null, packet), reply)
 
   function reply (err, packet) {
     arg.packet = packet
@@ -48,7 +49,8 @@ function pubrelWrite (arg, done) {
 
 function pubrelDel (arg, done) {
   const persistence = this.client.broker.persistence
-  persistence.incomingDelPacket(this.client, arg.packet, done)
+  persistence.incomingDelPacket(this.client, arg.packet)
+    .then(() => done(null), done)
 }
 
 module.exports = handlePubrel

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -131,9 +131,8 @@ function storeSubscriptions (sub, done) {
     return done(null, sub)
   }
 
-  client.broker.persistence.addSubscriptions(client, packet.subscriptions, function addSub (err) {
-    done(err, sub)
-  })
+  client.broker.persistence.addSubscriptions(client, packet.subscriptions)
+    .then(() => done(null, sub), err => done(err, sub))
 }
 
 function addSubs (sub, done) {

--- a/lib/handlers/unsubscribe.js
+++ b/lib/handlers/unsubscribe.js
@@ -35,13 +35,8 @@ function handleUnsubscribe (client, packet, done) {
       return actualUnsubscribe(client, packet, done)
     }
 
-    broker.persistence.removeSubscriptions(client, unsubscriptions, function (err) {
-      if (err) {
-        return done(err)
-      }
-
-      actualUnsubscribe(client, packet, done)
-    })
+    broker.persistence.removeSubscriptions(client, unsubscriptions)
+      .then(() => actualUnsubscribe(client, packet, done), done)
   } else {
     actualUnsubscribe(client, packet, done)
   }

--- a/test/auth.js
+++ b/test/auth.js
@@ -840,9 +840,8 @@ test('negate subscription with correct persistence', function (t) {
   s.outStream.once('data', function (packet) {
     t.equal(packet.cmd, 'suback')
     t.same(packet.granted, [128, 0])
-    broker.persistence.subscriptionsByClient(broker.clients.abcde, function (_, subs, client) {
-      t.same(subs, expected)
-    })
+    broker.persistence.subscriptionsByClient(broker.clients.abcde)
+      .then(subs => { t.same(subs, expected) })
     t.equal(packet.messageId, 24)
   })
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -144,9 +144,10 @@ test('publish to $SYS topic throws error', function (t) {
         t.same(packet, expected, 'packet matches')
       })
 
-      s.broker.persistence.subscriptionsByClient(s.client, function (_, subs) {
-        t.same(subs, expectedSubs)
-      })
+      s.broker.persistence.subscriptionsByClient(s.client)
+        .then(subs => {
+          t.same(subs.length > 0 ? subs : null, expectedSubs)
+        })
 
       s.broker.publish({
         cmd: 'publish',
@@ -208,9 +209,10 @@ test('return write errors to callback', function (t) {
         t.same(packet, expected, 'packet matches')
       })
 
-      s.broker.persistence.subscriptionsByClient(s.client, function (_, saveSubs) {
-        t.same(saveSubs, expectedSubs)
-      })
+      s.broker.persistence.subscriptionsByClient(s.client)
+        .then(saveSubs => {
+          t.same(saveSubs.length > 0 ? saveSubs : null, expectedSubs)
+        })
 
       s.broker.publish({
         cmd: 'publish',
@@ -697,9 +699,10 @@ test('do not restore QoS 0 subscriptions when clean', function (t) {
   }, function () {
     subscribe(t, subscriber, 'hello', 0, function () {
       subscriber.inStream.end()
-      subscriber.broker.persistence.subscriptionsByClient(broker.clients.abcde, function (_, subs, client) {
-        t.equal(subs, null, 'no previous subscriptions restored')
-      })
+      subscriber.broker.persistence.subscriptionsByClient(broker.clients.abcde)
+        .then(subs => {
+          t.equal(subs.length > 0 ? subs : null, null, 'no previous subscriptions restored')
+        })
       const publisher = connect(setup(broker), {
       }, function () {
         subscriber = connect(setup(broker), {

--- a/test/client-pub-sub.js
+++ b/test/client-pub-sub.js
@@ -43,8 +43,8 @@ test('publish direct to a single client throws error', function (t) {
   const broker = aedes()
   t.teardown(broker.close.bind(broker))
 
-  broker.persistence.outgoingEnqueue = function (sub, packet, done) {
-    done(new Error('Throws error'))
+  broker.persistence.outgoingEnqueue = async () => {
+    throw new Error('Throws error')
   }
 
   broker.on('client', function (client) {
@@ -67,8 +67,8 @@ test('publish direct to a single client throws error 2', function (t) {
   const broker = aedes()
   t.teardown(broker.close.bind(broker))
 
-  broker.persistence.outgoingUpdate = function (client, packet, done) {
-    done(new Error('Throws error'), client, packet)
+  broker.persistence.outgoingUpdate = async function () {
+    throw new Error('Throws error')
   }
 
   broker.on('client', function (client) {
@@ -143,8 +143,8 @@ test('publish QoS 2 throws error in pubrel', function (t) {
         cmd: 'pubrec',
         messageId: packet.messageId
       })
-      s.broker.persistence.outgoingUpdate = function (client, pubrel, cb) {
-        cb(new Error('error'))
+      s.broker.persistence.outgoingUpdate = async function () {
+        throw new Error('error')
       }
     }
   })
@@ -637,8 +637,8 @@ test('unsubscribe should not call removeSubscriptions when [clean=true]', functi
   const broker = aedes()
   t.teardown(broker.close.bind(broker))
 
-  broker.persistence.removeSubscriptions = function (client, subs, cb) {
-    cb(Error('remove subscription is called'))
+  broker.persistence.removeSubscriptions = async () => {
+    throw new Error('remove subscription is called')
   }
 
   broker.on('client', function (client) {
@@ -699,8 +699,8 @@ test('unsubscribe throws error 2', function (t) {
       qos: 2
     }, function (err) {
       t.error(err, 'no error')
-      broker.persistence.removeSubscriptions = function (client, unsubscriptions, done) {
-        done(new Error('error'))
+      broker.persistence.removeSubscriptions = async () => {
+        throw new Error('error')
       }
       client.unsubscribe({
         unsubscriptions: [{

--- a/test/will.js
+++ b/test/will.js
@@ -72,7 +72,7 @@ test('calling close two times should not deliver two wills', function (t) {
 })
 
 test('delivers old will in case of a crash', function (t) {
-  t.plan(8)
+  t.plan(7)
 
   const persistence = memory()
   const will = {
@@ -86,47 +86,45 @@ test('delivers old will in case of a crash', function (t) {
     id: 'anotherBroker'
   }
 
-  persistence.putWill({
-    id: 'myClientId42'
-  }, will, function (err) {
-    t.error(err, 'no error')
+  persistence.putWill({ id: 'myClientId42' }, will)
+    .then(() => {
+      let authorized = false
+      const interval = 10 // ms, so that the will check happens fast!
+      const broker = aedes({
+        persistence,
+        heartbeatInterval: interval,
+        authorizePublish: function (client, packet, callback) {
+          t.strictSame(client, null, 'client must be null')
+          authorized = true
+          callback(null)
+        }
+      })
+      t.teardown(broker.close.bind(broker))
 
-    let authorized = false
-    const interval = 10 // ms, so that the will check happens fast!
-    const broker = aedes({
-      persistence,
-      heartbeatInterval: interval,
-      authorizePublish: function (client, packet, callback) {
-        t.strictSame(client, null, 'client must be null')
-        authorized = true
-        callback(null)
+      const start = Date.now()
+
+      broker.mq.on('mywill', check)
+
+      function check (packet, cb) {
+        broker.mq.removeListener('mywill', check, function () {
+          broker.mq.on('mywill', function (packet) {
+            t.fail('the will must be delivered only once')
+          })
+        })
+        t.ok(Date.now() - start >= 3 * interval, 'the will needs to be emitted after 3 heartbeats')
+        t.equal(packet.topic, will.topic, 'topic matches')
+        t.same(packet.payload, will.payload, 'payload matches')
+        t.equal(packet.qos, will.qos, 'qos matches')
+        t.equal(packet.retain, will.retain, 'retain matches')
+        t.equal(authorized, true, 'authorization called')
+        cb()
       }
     })
-    t.teardown(broker.close.bind(broker))
-
-    const start = Date.now()
-
-    broker.mq.on('mywill', check)
-
-    function check (packet, cb) {
-      broker.mq.removeListener('mywill', check, function () {
-        broker.mq.on('mywill', function (packet) {
-          t.fail('the will must be delivered only once')
-        })
-      })
-      t.ok(Date.now() - start >= 3 * interval, 'the will needs to be emitted after 3 heartbeats')
-      t.equal(packet.topic, will.topic, 'topic matches')
-      t.same(packet.payload, will.payload, 'payload matches')
-      t.equal(packet.qos, will.qos, 'qos matches')
-      t.equal(packet.retain, will.retain, 'retain matches')
-      t.equal(authorized, true, 'authorization called')
-      cb()
-    }
-  })
+    .catch(err => t.error(err, 'no error'))
 })
 
 test('deliver old will without authorization in case of a crash', function (t) {
-  t.plan(2)
+  t.plan(1)
 
   const persistence = memory()
   const will = {
@@ -140,30 +138,28 @@ test('deliver old will without authorization in case of a crash', function (t) {
     id: 'anotherBroker'
   }
 
-  persistence.putWill({
-    id: 'myClientId42'
-  }, will, function (err) {
-    t.error(err, 'no error')
+  persistence.putWill({ id: 'myClientId42' }, will)
+    .then(() => {
+      const interval = 10 // ms, so that the will check happens fast!
+      const broker = aedes({
+        persistence,
+        heartbeatInterval: interval,
+        authorizePublish: function (client, packet, callback) {
+          t.strictSame(client, null, 'client must be null')
+          callback(new Error())
+        }
+      })
 
-    const interval = 10 // ms, so that the will check happens fast!
-    const broker = aedes({
-      persistence,
-      heartbeatInterval: interval,
-      authorizePublish: function (client, packet, callback) {
-        t.strictSame(client, null, 'client must be null')
-        callback(new Error())
+      t.teardown(broker.close.bind(broker))
+
+      broker.mq.on('mywill', check)
+
+      function check (packet, cb) {
+        t.fail('received will without authorization')
+        cb()
       }
     })
-
-    t.teardown(broker.close.bind(broker))
-
-    broker.mq.on('mywill', check)
-
-    function check (packet, cb) {
-      t.fail('received will without authorization')
-      cb()
-    }
-  })
+    .catch(err => t.error(err, 'no error'))
 })
 
 test('delete old broker', function (t) {
@@ -191,7 +187,7 @@ test('delete old broker', function (t) {
 })
 
 test('store the will in the persistence', function (t) {
-  t.plan(5)
+  t.plan(4)
 
   const opts = {
     clientId: 'abcde'
@@ -203,20 +199,19 @@ test('store the will in the persistence', function (t) {
 
   s.broker.on('client', function () {
     // this is connack
-    s.broker.persistence.getWill({
-      id: opts.clientId
-    }, function (err, packet) {
-      t.error(err, 'no error')
-      t.same(packet.topic, opts.will.topic, 'will topic matches')
-      t.same(packet.payload, opts.will.payload, 'will payload matches')
-      t.same(packet.qos, opts.will.qos, 'will qos matches')
-      t.same(packet.retain, opts.will.retain, 'will retain matches')
-    })
+    s.broker.persistence.getWill({ id: opts.clientId })
+      .then(packet => {
+        t.same(packet.topic, opts.will.topic, 'will topic matches')
+        t.same(packet.payload, opts.will.payload, 'will payload matches')
+        t.same(packet.qos, opts.will.qos, 'will qos matches')
+        t.same(packet.retain, opts.will.retain, 'will retain matches')
+      })
+      .catch(err => t.error(err, 'no error'))
   })
 })
 
 test('delete the will in the persistence after publish', function (t) {
-  t.plan(2)
+  t.plan(1)
 
   const opts = {
     clientId: 'abcde'
@@ -238,12 +233,9 @@ test('delete the will in the persistence after publish', function (t) {
 
   function check (packet, cb) {
     broker.mq.removeListener('mywill', check, function () {
-      broker.persistence.getWill({
-        id: opts.clientId
-      }, function (err, p) {
-        t.error(err, 'no error')
-        t.notOk(p, 'packet is empty')
-      })
+      broker.persistence.getWill({ id: opts.clientId })
+        .then(p => t.notOk(p, 'packet is empty'))
+        .catch(err => t.error(err, 'no error'))
     })
     cb()
   }
@@ -421,7 +413,7 @@ test('does not deliver will when client sends a DISCONNECT', function (t) {
 })
 
 test('deletes from persistence on DISCONNECT', function (t) {
-  t.plan(2)
+  t.plan(1)
 
   const opts = {
     clientId: 'abcde'
@@ -435,16 +427,13 @@ test('deletes from persistence on DISCONNECT', function (t) {
     })
   }), t)
 
-  s.broker.persistence.getWill({
-    id: opts.clientId
-  }, function (err, packet) {
-    t.error(err, 'no error')
-    t.notOk(packet)
-  })
+  s.broker.persistence.getWill({ id: opts.clientId })
+    .then(packet => t.notOk(packet))
+    .catch(err => t.error(err, 'no error'))
 })
 
 test('does not store multiple will with same clientid', function (t) {
-  t.plan(4)
+  t.plan(2)
 
   const opts = { clientId: 'abcde' }
 
@@ -461,15 +450,17 @@ test('does not store multiple will with same clientid', function (t) {
     // reconnect same client with will
     s = willConnect(setup(broker), opts, function () {
       // check that there are not 2 will messages for the same clientid
-      s.broker.persistence.delWill({ id: opts.clientId }, function (err, packet) {
-        t.error(err, 'no error')
-        t.equal(packet.clientId, opts.clientId, 'will packet found')
-        s.broker.persistence.delWill({ id: opts.clientId }, function (err, packet) {
-          t.error(err, 'no error')
-          t.equal(!!packet, false, 'no duplicated packets')
-          broker.close()
+      s.broker.persistence.delWill({ id: opts.clientId })
+        .then(packet => {
+          t.equal(packet.clientId, opts.clientId, 'will packet found')
+          s.broker.persistence.delWill({ id: opts.clientId })
+            .then(packet => {
+              t.equal(!!packet, false, 'no duplicated packets')
+              broker.close()
+            })
+            .catch(err => t.error(err, 'no error'))
         })
-      })
+        .catch(err => t.error(err, 'no error'))
     })
   })
 })
@@ -489,45 +480,43 @@ test('don\'t delivers a will if broker alive', function (t) {
     id: oldBroker
   }
 
-  persistence.putWill({
-    id: 'myClientId42'
-  }, will, function (err) {
-    t.error(err, 'no error')
-
-    const opts = {
-      persistence,
-      heartbeatInterval: 10
-    }
-
-    let count = 0
-
-    const broker = aedes(opts)
-    t.teardown(broker.close.bind(broker))
-
-    const streamWill = persistence.streamWill
-    persistence.streamWill = function () {
-      // don't pass broker.brokers to streamWill
-      return streamWill.call(persistence)
-    }
-
-    broker.mq.on('mywill', function (packet, cb) {
-      t.fail('Will received')
-      cb()
-    })
-
-    broker.mq.on('$SYS/+/heartbeat', function () {
-      t.pass('Heartbeat received')
-      broker.brokers[oldBroker] = Date.now()
-
-      if (++count === 5) {
-        t.end()
+  persistence.putWill({ id: 'myClientId42' }, will)
+    .then(() => {
+      const opts = {
+        persistence,
+        heartbeatInterval: 10
       }
+
+      let count = 0
+
+      const broker = aedes(opts)
+      t.teardown(broker.close.bind(broker))
+
+      const streamWill = persistence.streamWill
+      persistence.streamWill = function () {
+        // don't pass broker.brokers to streamWill
+        return streamWill.call(persistence)
+      }
+
+      broker.mq.on('mywill', function (packet, cb) {
+        t.fail('Will received')
+        cb()
+      })
+
+      broker.mq.on('$SYS/+/heartbeat', function () {
+        t.pass('Heartbeat received')
+        broker.brokers[oldBroker] = Date.now()
+
+        if (++count === 5) {
+          t.end()
+        }
+      })
     })
-  })
+    .catch(err => t.error(err, 'no error'))
 })
 
 test('handle will publish error', function (t) {
-  t.plan(2)
+  t.plan(1)
   const persistence = memory()
   const will = {
     topic: 'mywill',
@@ -540,31 +529,29 @@ test('handle will publish error', function (t) {
     id: 'broker1'
   }
 
-  persistence.putWill({
-    id: 'myClientId42'
-  }, will, function (err) {
-    t.error(err, 'no error')
+  persistence.putWill({ id: 'myClientId42' }, will)
+    .then(() => {
+      const opts = {
+        persistence,
+        heartbeatInterval: 10
+      }
 
-    const opts = {
-      persistence,
-      heartbeatInterval: 10
-    }
+      persistence.delWill = async function (client) {
+        throw new Error('Throws error')
+      }
 
-    persistence.delWill = function (client, cb) {
-      cb(new Error('Throws error'))
-    }
+      const broker = aedes(opts)
+      t.teardown(broker.close.bind(broker))
 
-    const broker = aedes(opts)
-    t.teardown(broker.close.bind(broker))
-
-    broker.once('error', function (err) {
-      t.equal('Throws error', err.message, 'throws error')
+      broker.once('error', function (err) {
+        t.equal('Throws error', err.message, 'throws error')
+      })
     })
-  })
+    .catch(err => t.error(err, 'no error'))
 })
 
 test('handle will publish error 2', function (t) {
-  t.plan(2)
+  t.plan(1)
   const persistence = memory()
   const will = {
     topic: 'mywill',
@@ -577,25 +564,23 @@ test('handle will publish error 2', function (t) {
     id: 'broker1'
   }
 
-  persistence.putWill({
-    id: 'myClientId42'
-  }, will, function (err) {
-    t.error(err, 'no error')
+  persistence.putWill({ id: 'myClientId42' }, will)
+    .then(() => {
+      const opts = {
+        persistence,
+        heartbeatInterval: 10
+      }
 
-    const opts = {
-      persistence,
-      heartbeatInterval: 10
-    }
+      persistence.storeRetained = async function (packet) {
+        throw new Error('Throws error')
+      }
 
-    persistence.storeRetained = function (packet, cb) {
-      cb(new Error('Throws error'))
-    }
+      const broker = aedes(opts)
+      t.teardown(broker.close.bind(broker))
 
-    const broker = aedes(opts)
-    t.teardown(broker.close.bind(broker))
-
-    broker.once('error', function (err) {
-      t.equal('Throws error', err.message, 'throws error')
+      broker.once('error', function (err) {
+        t.equal('Throws error', err.message, 'throws error')
+      })
     })
-  })
+    .catch(err => t.error(err, 'no error'))
 })


### PR DESCRIPTION
This PR migrates Aedes to use the async persistence interface.

It contains the following sub items:

- [X] replace all callback calls to persistence by `.then()` calls
- [ ] move all side effects (setting up persistence, attaching event handlers etc) to a `setup()` method of Aedes
- [ ] update `createBroker()` to be async and make it await `setup()` as well
- [ ] update exports so that they produce a warning if people use old style calling
- [ ] update documentation including examples
- [ ] add a `migration.md` to help users migrate.

Kind regards,
Hans


