### PR TITLE
feat: automate benchmark on PR requests using Github Actions

### DIFF
--- a/.github/actions/sticky-pr-comment/action.yml
+++ b/.github/actions/sticky-pr-comment/action.yml
@@ -1,0 +1,55 @@
+name: "Sticky PR Comment"
+description: "Posts or updates a pull request comment identified by a tag."
+inputs:
+  file:
+    description: "Path to the file whose contents are to be posted"
+    required: true
+  tag:
+    description: "Unique tag to identify the comment (e.g. <!-- BENCHMARK_REPORT_COMMENT -->)"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Read file and set as output
+      id: file
+      shell: bash
+      run: |
+        echo "body<<EOF" >> $GITHUB_OUTPUT
+        cat "${{ inputs.file }}" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+
+    - name: Post or update PR comment
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ github.token }}
+        script: |
+          const tag = `${{ inputs.tag }}`;
+          const body = `${tag}\n${{ steps.file.outputs.body }}`;
+          const pr = context.payload.pull_request?.number;
+          if (!pr) {
+            core.setFailed("No pull request found in context.");
+            return;
+          }
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr,
+          });
+          const tagged = comments.find(comment =>
+            comment.body.includes(tag)
+          );
+          if (tagged) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: tagged.id,
+              body: body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body: body,
+            });
+          }

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -56,6 +56,5 @@ jobs:
         shell: bash
         run: |
           cat results.main.csv results.branch.csv | node main-source/benchmarks/report.js >> $GITHUB_STEP_SUMMARY
-          exit $?
 
      

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -5,24 +5,20 @@ description: "Runs benchmarks and posts or updates a sticky PR comment with the 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      node-version:
+        description: "Node.js version"
+        default: "20"
+        required: false
+      main-ref:
+        description: "Git ref for the main branch (e.g. main or master)"
+        default: "main"
+        required: false
 
 permissions:
   contents: read
   pull-requests: write # Required for commenting on PRs
-
-inputs:
-  node-version:
-    description: "Node.js version"
-    default: "20"
-    required: false
-  main-ref:
-    description: "Git ref for the main branch (e.g. main or master)"
-    default: "main"
-    required: false
-  report-tag:
-    description: "Tag added to the PR comment to identify it for updating"
-    default: "<!-- BENCHMARK_REPORT_COMMENT -->"
-    required: false
 
 jobs:
   benchmark:

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: ${{ github.event.inputs.nodeVersion }}
 
       - name: Install dependencies (main)
-        run: npm ci
+        run: npm install --ignore-scripts
         working-directory: main-source
 
       - name: Run benchmark on main
@@ -57,7 +57,7 @@ jobs:
           node-version: ${{github.event.inputs.nodeVersion }}
 
       - name: Install dependencies (PR)
-        run: npm ci
+        run: npm install --ignore-scripts
         working-directory: pr-source
 
       - name: Run benchmark on PR branch

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -1,4 +1,5 @@
 name: "Benchmark Report"
+
 description: "Runs benchmarks and posts or updates a sticky PR comment with the results."
 
 on:
@@ -8,7 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: write # Required for commenting on PRs
-  
+
 inputs:
   node-version:
     description: "Node.js version"
@@ -23,8 +24,7 @@ inputs:
     default: "<!-- BENCHMARK_REPORT_COMMENT -->"
     required: false
 
-runs:
-  using: "composite"
+jobs:
   steps:
     # Run benchmark on main branch
     - name: Checkout main branch

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -73,7 +73,7 @@ jobs:
 
       # Post or update sticky PR comment
       - name: Post or Update Benchmark Comment
-        uses: ./.github/actions/sticky-comment 
+        uses: ./pr-source/.github/actions/sticky-comment 
         with:
           file: result.md
           tag: "<!-- BENCHMARK_REPORT_COMMENT -->" # This tag will identify the stick comment

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Run benchmark on main
         run: node benchmarks/runBenchmarks.js > ../results.main.csv
         working-directory: main-source
-        continue-on-error: true
 
       # Run benchmark on PR branch
       - name: Checkout PR branch
@@ -73,7 +72,7 @@ jobs:
 
       # Post or update sticky PR comment
       - name: Post or Update Benchmark Comment
-        uses: ./pr-source/.github/actions/sticky-comment 
+        uses: ./pr-source/.github/actions/sticky-pr-comment
         with:
           file: result.md
           tag: "<!-- BENCHMARK_REPORT_COMMENT -->" # This tag will identify the stick comment

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: main-source
 
       - name: Run benchmark on main
-        run: node benchmarks/runBenchmark.js > ../results.main.csv
+        run: node benchmarks/runBenchmarks.js > ../results.main.csv
         working-directory: main-source
         continue-on-error: true
 
@@ -62,10 +62,7 @@ jobs:
         working-directory: pr-source
 
       - name: Run benchmark on PR branch
-        run: |
-          pwd
-          ls
-          node benchmarks/runBenchmark.js > ../results.branch.csv
+        run: node benchmarks/runBenchmarks.js > ../results.branch.csv
         working-directory: pr-source
 
       # Generate the report

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: write # Required for commenting on PRs
+  issues: write
 
 jobs:
   benchmark:
@@ -61,11 +62,11 @@ jobs:
       - name: Generate report
         shell: bash
         run: |
-          cat results.main.csv results.branch.csv | node pr-source/benchmarks/report.js > result.md
+          cat results.main.csv results.branch.csv | node main-source/benchmarks/report.js > result.md
 
       # Post or update sticky PR comment
       - name: Post or Update Benchmark Comment
-        uses: ./pr-source/.github/actions/sticky-pr-comment
+        uses: ./main-source/.github/actions/sticky-pr-comment
         with:
           file: result.md
           tag: "<!-- BENCHMARK_REPORT_COMMENT -->" # This tag will identify the stick comment

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write # Required for commenting on PRs
+  
 inputs:
   node-version:
     description: "Node.js version"
@@ -18,7 +22,7 @@ inputs:
     description: "Tag added to the PR comment to identify it for updating"
     default: "<!-- BENCHMARK_REPORT_COMMENT -->"
     required: false
-    
+
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -17,17 +17,18 @@ jobs:
       nodeVersion: 20
       mainRef: "main"
     steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.nodeVersion }}
+          cache: npm
+
       # Run benchmark on main branch
       - name: Checkout main branch
         uses: actions/checkout@v4
         with:
           ref: ${{ env.mainRef }}
           path: main-source
-
-      - name: Set up Node.js (main)
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.nodeVersion }}
 
       - name: Install dependencies (main)
         run: npm install --ignore-scripts
@@ -43,11 +44,6 @@ jobs:
         with:
           path: pr-source
 
-      - name: Set up Node.js (PR)
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.nodeVersion }}
-
       - name: Install dependencies (PR)
         run: npm install --ignore-scripts
         working-directory: pr-source
@@ -61,5 +57,6 @@ jobs:
         shell: bash
         run: |
           cat results.main.csv results.branch.csv | node main-source/benchmarks/report.js >> $GITHUB_STEP_SUMMARY
+          exit $?
 
      

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write # Required for commenting on PRs
-  issues: write
 
 jobs:
   benchmark:
@@ -62,11 +60,6 @@ jobs:
       - name: Generate report
         shell: bash
         run: |
-          cat results.main.csv results.branch.csv | node main-source/benchmarks/report.js > result.md
+          cat results.main.csv results.branch.csv | node main-source/benchmarks/report.js >> $GITHUB_STEP_SUMMARY
 
-      # Post or update sticky PR comment
-      - name: Post or Update Benchmark Comment
-        uses: ./main-source/.github/actions/sticky-pr-comment
-        with:
-          file: result.md
-          tag: "<!-- BENCHMARK_REPORT_COMMENT -->" # This tag will identify the stick comment
+     

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -25,55 +25,57 @@ inputs:
     required: false
 
 jobs:
-  steps:
-    # Run benchmark on main branch
-    - name: Checkout main branch
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ inputs.main-ref }}
-        path: main-source
+  benchmark:
+    name: Benchmark
+    steps:
+      # Run benchmark on main branch
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.main-ref }}
+          path: main-source
 
-    - name: Set up Node.js (main)
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ inputs.node-version }}
+      - name: Set up Node.js (main)
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
 
-    - name: Install dependencies (main)
-      run: npm ci
-      working-directory: main-source
+      - name: Install dependencies (main)
+        run: npm ci
+        working-directory: main-source
 
-    - name: Run benchmark on main
-      run: node benchmarks/runBenchmark.js > ../results.main.csv
-      working-directory: main-source
+      - name: Run benchmark on main
+        run: node benchmarks/runBenchmark.js > ../results.main.csv
+        working-directory: main-source
 
-    # Run benchmark on PR branch
-    - name: Checkout PR branch
-      uses: actions/checkout@v4
-      with:
-        path: pr-source
+      # Run benchmark on PR branch
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          path: pr-source
 
-    - name: Set up Node.js (PR)
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ inputs.node-version }}
+      - name: Set up Node.js (PR)
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
 
-    - name: Install dependencies (PR)
-      run: npm ci
-      working-directory: pr-source
+      - name: Install dependencies (PR)
+        run: npm ci
+        working-directory: pr-source
 
-    - name: Run benchmark on PR branch
-      run: node benchmarks/runBenchmark.js > ../results.branch.csv
-      working-directory: pr-source
+      - name: Run benchmark on PR branch
+        run: node benchmarks/runBenchmark.js > ../results.branch.csv
+        working-directory: pr-source
 
-    # Generate the report
-    - name: Generate report
-      shell: bash
-      run: |
-        cat results.main.csv results.branch.csv | node pr-source/benchmarks/report.js > result.md
+      # Generate the report
+      - name: Generate report
+        shell: bash
+        run: |
+          cat results.main.csv results.branch.csv | node pr-source/benchmarks/report.js > result.md
 
-    # Post or update sticky PR comment
-    - name: Post or Update Benchmark Comment
-      uses: ./.github/actions/sticky-comment 
-      with:
-        file: result.md
-        tag: "<!-- BENCHMARK_REPORT_COMMENT -->" # This tag will identify the stick comment
+      # Post or update sticky PR comment
+      - name: Post or Update Benchmark Comment
+        uses: ./.github/actions/sticky-comment 
+        with:
+          file: result.md
+          tag: "<!-- BENCHMARK_REPORT_COMMENT -->" # This tag will identify the stick comment

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -62,6 +62,8 @@ jobs:
         working-directory: pr-source
 
       - name: Run benchmark on PR branch
+        run: pwd
+        run: ls
         run: node benchmarks/runBenchmark.js > ../results.branch.csv
         working-directory: pr-source
 

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -1,5 +1,10 @@
 name: "Benchmark Report"
 description: "Runs benchmarks and posts or updates a sticky PR comment with the results."
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
 inputs:
   node-version:
     description: "Node.js version"
@@ -13,6 +18,7 @@ inputs:
     description: "Tag added to the PR comment to identify it for updating"
     default: "<!-- BENCHMARK_REPORT_COMMENT -->"
     required: false
+    
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -12,8 +12,8 @@ on:
         default: "20"
         required: false
       mainRef:
-        description: "Git ref for the main branch (e.g. main or master)"
-        default: ${{ github.base_ref }}
+        description: "Git ref of the branch to compare to"
+        default: "main"
         required: false
 
 permissions:

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -13,7 +13,7 @@ on:
         required: false
       mainRef:
         description: "Git ref for the main branch (e.g. main or master)"
-        default: "main"
+        default: ${{ github.base_ref }}
         required: false
 
 permissions:
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout main branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.mainRef}}
+          ref: ${{ github.event.inputs.mainRef }}
           path: main-source
 
       - name: Set up Node.js (main)
@@ -42,7 +42,7 @@ jobs:
         working-directory: main-source
 
       - name: Run benchmark on main
-        run: node benchmarks/runBenchmarks.js > ../results.main.csv
+        run: node benchmarks/runBenchmarks.js ${{ github.event.inputs.mainRef }} > ../results.main.csv
         working-directory: main-source
 
       # Run benchmark on PR branch
@@ -61,7 +61,7 @@ jobs:
         working-directory: pr-source
 
       - name: Run benchmark on PR branch
-        run: node benchmarks/runBenchmarks.js > ../results.branch.csv
+        run: node benchmarks/runBenchmarks.js ${{ github.head_ref }} > ../results.branch.csv
         working-directory: pr-source
 
       # Generate the report

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -5,16 +5,6 @@ description: "Runs benchmarks and posts or updates a sticky PR comment with the 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  workflow_dispatch:
-    inputs:
-      nodeVersion:
-        description: "Node.js version"
-        default: "20"
-        required: false
-      mainRef:
-        description: "Git ref of the branch to compare to"
-        default: "main"
-        required: false
 
 permissions:
   contents: read
@@ -24,25 +14,28 @@ jobs:
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
+    env: 
+      nodeVersion: 20
+      mainRef: "main"
     steps:
       # Run benchmark on main branch
       - name: Checkout main branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.mainRef }}
+          ref: ${{ env.mainRef }}
           path: main-source
 
       - name: Set up Node.js (main)
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ github.event.inputs.nodeVersion }}
+          node-version: ${{ env.nodeVersion }}
 
       - name: Install dependencies (main)
         run: npm install --ignore-scripts
         working-directory: main-source
 
       - name: Run benchmark on main
-        run: node benchmarks/runBenchmarks.js ${{ github.event.inputs.mainRef }} > ../results.main.csv
+        run: node benchmarks/runBenchmarks.js > ../results.main.csv
         working-directory: main-source
 
       # Run benchmark on PR branch
@@ -54,14 +47,14 @@ jobs:
       - name: Set up Node.js (PR)
         uses: actions/setup-node@v4
         with:
-          node-version: ${{github.event.inputs.nodeVersion }}
+          node-version: ${{ env.nodeVersion }}
 
       - name: Install dependencies (PR)
         run: npm install --ignore-scripts
         working-directory: pr-source
 
       - name: Run benchmark on PR branch
-        run: node benchmarks/runBenchmarks.js ${{ github.head_ref }} > ../results.branch.csv
+        run: node benchmarks/runBenchmarks.js > ../results.branch.csv
         working-directory: pr-source
 
       # Generate the report

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -7,11 +7,11 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
-      node-version:
+      nodeVersion:
         description: "Node.js version"
         default: "20"
         required: false
-      main-ref:
+      mainRef:
         description: "Git ref for the main branch (e.g. main or master)"
         default: "main"
         required: false
@@ -23,18 +23,19 @@ permissions:
 jobs:
   benchmark:
     name: Benchmark
+    runs-on: ubuntu-latest
     steps:
       # Run benchmark on main branch
       - name: Checkout main branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.main-ref }}
+          ref: ${{ github.event.inputs.mainRef}}
           path: main-source
 
       - name: Set up Node.js (main)
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ inputs.node-version }}
+          node-version: ${{ github.event.inputs.nodeVersion }}
 
       - name: Install dependencies (main)
         run: npm ci
@@ -53,7 +54,7 @@ jobs:
       - name: Set up Node.js (PR)
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ inputs.node-version }}
+          node-version: ${{github.event.inputs.nodeVersion }}
 
       - name: Install dependencies (PR)
         run: npm ci

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Run benchmark on main
         run: node benchmarks/runBenchmark.js > ../results.main.csv
         working-directory: main-source
+        continue-on-error: true
 
       # Run benchmark on PR branch
       - name: Checkout PR branch

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.nodeVersion }}
-          cache: npm
 
       # Run benchmark on main branch
       - name: Checkout main branch

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -1,0 +1,69 @@
+name: "Benchmark Report"
+description: "Runs benchmarks and posts or updates a sticky PR comment with the results."
+inputs:
+  node-version:
+    description: "Node.js version"
+    default: "20"
+    required: false
+  main-ref:
+    description: "Git ref for the main branch (e.g. main or master)"
+    default: "main"
+    required: false
+  report-tag:
+    description: "Tag added to the PR comment to identify it for updating"
+    default: "<!-- BENCHMARK_REPORT_COMMENT -->"
+    required: false
+runs:
+  using: "composite"
+  steps:
+    # Run benchmark on main branch
+    - name: Checkout main branch
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.main-ref }}
+        path: main-source
+
+    - name: Set up Node.js (main)
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install dependencies (main)
+      run: npm ci
+      working-directory: main-source
+
+    - name: Run benchmark on main
+      run: node benchmarks/runBenchmark.js > ../results.main.csv
+      working-directory: main-source
+
+    # Run benchmark on PR branch
+    - name: Checkout PR branch
+      uses: actions/checkout@v4
+      with:
+        path: pr-source
+
+    - name: Set up Node.js (PR)
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install dependencies (PR)
+      run: npm ci
+      working-directory: pr-source
+
+    - name: Run benchmark on PR branch
+      run: node benchmarks/runBenchmark.js > ../results.branch.csv
+      working-directory: pr-source
+
+    # Generate the report
+    - name: Generate report
+      shell: bash
+      run: |
+        cat results.main.csv results.branch.csv | node pr-source/benchmarks/report.js > result.md
+
+    # Post or update sticky PR comment
+    - name: Post or Update Benchmark Comment
+      uses: ./.github/actions/sticky-comment 
+      with:
+        file: result.md
+        tag: "<!-- BENCHMARK_REPORT_COMMENT -->" # This tag will identify the stick comment

--- a/.github/workflows/benchmark-compare-serial.yml
+++ b/.github/workflows/benchmark-compare-serial.yml
@@ -62,9 +62,10 @@ jobs:
         working-directory: pr-source
 
       - name: Run benchmark on PR branch
-        run: pwd
-        run: ls
-        run: node benchmarks/runBenchmark.js > ../results.branch.csv
+        run: |
+          pwd
+          ls
+          node benchmarks/runBenchmark.js > ../results.branch.csv
         working-directory: pr-source
 
       # Generate the report

--- a/benchmarks/runBenchmarks.js
+++ b/benchmarks/runBenchmarks.js
@@ -2,7 +2,7 @@ const { fork, execSync } = require('node:child_process')
 const { cpus } = require('node:os')
 const path = require('node:path')
 
-const gitBranch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim()
+const gitBranch = process.argv[2] || execSync('git rev-parse --abbrev-ref HEAD').toString().trim()
 const numCores = cpus().length
 const cpuType = cpus()[0].model.trim()
 

--- a/benchmarks/runBenchmarks.js
+++ b/benchmarks/runBenchmarks.js
@@ -2,7 +2,7 @@ const { fork, execSync } = require('node:child_process')
 const { cpus } = require('node:os')
 const path = require('node:path')
 
-const gitBranch = process.argv[2] || execSync('git rev-parse --abbrev-ref HEAD').toString().trim()
+const gitBranch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim()
 const numCores = cpus().length
 const cpuType = cpus()[0].model.trim()
 


### PR DESCRIPTION
This PR adds Github actions to automate benchmark running on PR requests

It will create a [Github Job Summary](https://github.blog/news-insights/product-news/supercharging-github-actions-with-job-summaries/) of the benchmark and add it to the benchmark action (see https://github.com/moscajs/aedes/actions/runs/16239498783#summary-45853979456 )

The benchmark steps run serialized in the hope that performance on a single runner does not vary too much.
I have been building testing this using https://github.com/seriousme/aedes/pull/1 which also shows how it operates.

It also shows that variation between results is inevitable, even when running on the same runner and the Aedes code is identical !!

In https://github.com/seriousme/aedes/pull/1  I was able to add the comment automatically to the PR using  `.github/actions/sticky-pr-comment/action.yml`  however if you send a PR from a fork the GITHUB_TOKEN that runs the actions by default (event: [pull_request](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request)  ) only has `read` access on the PR for security reasons (see [Pull Request events for forked repositories](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-events-for-forked-repositories))

This can be fixed by attaching to the event: [pull_request_target](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target), however Github notes explicitly: *Avoid using this event if you need to build or run code from the pull request.*

So for now I used Github Job Summary instead.

Kind regards,
Hans