### PR TITLE
chore: reduce production dependencies

### DIFF
--- a/aedes.js
+++ b/aedes.js
@@ -381,9 +381,9 @@ function runSeries (state, actions, packet, done) {
   next()
 }
 
-async function closeClient (client) {
+async function closeClient (clientInstance) {
   return new Promise((resolve) => {
-    client.close(resolve)
+    clientInstance.close(resolve)
   })
 }
 

--- a/aedes.js
+++ b/aedes.js
@@ -5,7 +5,7 @@ import Packet from 'aedes-packet'
 import memory from 'aedes-persistence'
 import mqemitter from 'mqemitter'
 import Client from './lib/client.js'
-import { $SYS_PREFIX, bulk, ObjectPool } from './lib/utils.js'
+import { $SYS_PREFIX, bulk } from './lib/utils.js'
 import pkg from './package.json' with { type: 'json' }
 
 const defaultOptions = {
@@ -54,7 +54,6 @@ export class Aedes extends EventEmitter {
     }
 
     this._series = runSeries
-    this._enqueuers = new ObjectPool(DoEnqueues)
 
     this.preConnect = opts.preConnect
     this.authenticate = opts.authenticate
@@ -297,7 +296,7 @@ function emitPacket (packet, done) {
 }
 
 function enqueueOffline (packet, done) {
-  const enqueuer = this.broker._enqueuers.get()
+  const enqueuer = new DoEnqueues()
 
   enqueuer.complete = done
   enqueuer.packet = packet
@@ -341,7 +340,6 @@ class DoEnqueues {
 
       broker.persistence.outgoingEnqueueCombi(subs, packet)
         .then(() => complete(null), complete)
-      broker._enqueuers.release(that)
     }
   }
 }

--- a/aedes.js
+++ b/aedes.js
@@ -5,7 +5,7 @@ import Packet from 'aedes-packet'
 import memory from 'aedes-persistence'
 import mqemitter from 'mqemitter'
 import Client from './lib/client.js'
-import { $SYS_PREFIX, batch } from './lib/utils.js'
+import { $SYS_PREFIX, batch, noop, runSeries } from './lib/utils.js'
 import pkg from './package.json' with { type: 'json' }
 
 const defaultOptions = {
@@ -352,17 +352,6 @@ const publishFuncsQoS = [
   callPublished
 ]
 
-// runSeries runs functions in fastseries style
-function runSeries (state, actions, packet, done) {
-  done = (done || noop).bind(state)
-  let i = 0
-  function next (err) {
-    if (err || i === actions.length) return done(err)
-    actions[i++].call(state, packet, next)
-  }
-  next()
-}
-
 async function closeClient (clientInstance) {
   return new Promise((resolve) => {
     clientInstance.close(resolve)
@@ -403,8 +392,6 @@ class PublishState {
     this.packet = packet
   }
 }
-
-function noop () { }
 
 function warnMigrate () {
   throw new Error(

--- a/aedes.js
+++ b/aedes.js
@@ -258,7 +258,7 @@ export class Aedes extends EventEmitter {
     for (const clientId of Object.keys(this.clients)) {
       promises.push(closeClient(this.clients[clientId]))
     }
-    Promise.all(promises).then(() => {
+    Promise.all(promises).finally(() => {
       that.emit('closed')
       that.mq.close(cb)
     })

--- a/aedes.js
+++ b/aedes.js
@@ -54,8 +54,6 @@ export class Aedes extends EventEmitter {
       return new Client(that, conn, req)
     }
 
-    this._series = runSeries
-
     this.preConnect = opts.preConnect
     this.authenticate = opts.authenticate
     this.authorizePublish = opts.authorizePublish
@@ -200,7 +198,7 @@ export class Aedes extends EventEmitter {
     const p = new Packet(packet, this)
     const publishFuncs = p.qos > 0 ? publishFuncsQoS : publishFuncsSimple
 
-    this._series(new PublishState(this, client, packet), publishFuncs, p, done)
+    runSeries(new PublishState(this, client, packet), publishFuncs, p, done)
   }
 
   subscribe (topic, func, done) {

--- a/docs/Client.md
+++ b/docs/Client.md
@@ -62,7 +62,7 @@ a read-only flag indicates if client is closed or not.
 
 ## client.id
 
-- `<string>` __Default__: `aedes_${hyperid()}`
+- `<string>` __Default__: `aedes_${randomUUID()}`
 
 Client unique identifier, specified by CONNECT packet.
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,14 +1,13 @@
 import mqtt from 'mqtt-packet'
 import EventEmitter from 'node:events'
 import util from 'util'
-import eos from 'end-of-stream'
 import Packet from 'aedes-packet'
 import write from './write.js'
 import QoSPacket from './qos-packet.js'
 import handleSubscribe from './handlers/subscribe.js'
 import handleUnsubscribe from './handlers/unsubscribe.js'
 import handle from './handlers/index.js'
-import { pipeline } from 'stream'
+import { pipeline, finished } from 'stream'
 import { through } from './utils.js'
 
 class Client {
@@ -84,7 +83,7 @@ class Client {
     this._parser.on('error', this.emit.bind(this, 'error'))
 
     conn.on('end', this.close.bind(this))
-    this._eos = eos(this.conn, this.close.bind(this))
+    this._eos = finished(this.conn, this.close.bind(this))
 
     const getToForwardPacket = (_packet) => {
       // Mqttv5 3.8.3.1: https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html#_Toc3901169

--- a/lib/client.js
+++ b/lib/client.js
@@ -233,7 +233,7 @@ class Client {
     this._parser._queue = null
 
     if (this._keepaliveTimer) {
-      this._keepaliveTimer.clear()
+      clearTimeout(this._keepaliveTimer)
       this._keepaliveInterval = -1
       this._keepaliveTimer = null
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -170,9 +170,9 @@ class Client {
     this.conn.removeAllListeners('error')
     this.conn.on('error', noop)
     // hack to clean up the write callbacks in case of error
-    const state = this.conn._writableState
-    const list = typeof state.getBuffer === 'function' ? state.getBuffer() : state.buffer
-    list.forEach(drainRequest)
+    if (!this.conn.destroyed) {
+      this.conn.destroy(err)
+    }
     this.broker.emit(this.id ? 'clientError' : 'connectionError', this, err)
     this.close()
   }
@@ -458,10 +458,6 @@ function writeQoS (err, client, packet) {
       packet.writeCallback()
     })
   }
-}
-
-function drainRequest (req) {
-  req.callback()
 }
 
 util.inherits(Client, EventEmitter)

--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -1,12 +1,9 @@
-import retimer from 'retimer'
+import { randomUUID } from 'node:crypto'
 import { pipeline } from 'stream'
 import write from '../write.js'
 import QoSPacket from '../qos-packet.js'
-import { through } from '../utils.js'
+import { through, retimer } from '../utils.js'
 import handleSubscribe from './subscribe.js'
-import hyperid from 'hyperid'
-
-const uniqueId = hyperid()
 
 class Connack {
   constructor (arg) {
@@ -84,7 +81,7 @@ function init (client, packet, done) {
     return
   }
 
-  client.id = clientId || 'aedes_' + uniqueId()
+  client.id = clientId || 'aedes_' + randomUUID()
   client.clean = packet.clean
   client.version = packet.protocolVersion
   client._will = packet.will

--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { pipeline } from 'stream'
 import write from '../write.js'
 import QoSPacket from '../qos-packet.js'
-import { through, retimer } from '../utils.js'
+import { through } from '../utils.js'
 import handleSubscribe from './subscribe.js'
 
 class Connack {
@@ -147,12 +147,14 @@ function authenticate (arg, done) {
 function setKeepAlive (arg, done) {
   if (this.packet.keepalive > 0) {
     const client = this.client
-    // [MQTT-3.1.2-24]
-    client._keepaliveInterval = (this.packet.keepalive * 1500) + 1
-    client._keepaliveTimer = retimer(function keepaliveTimeout () {
+
+    function keepaliveTimeout () {
       client.broker.emit('keepaliveTimeout', client)
       client.emit('error', new Error('keep alive timeout'))
-    }, client._keepaliveInterval)
+    }
+    // [MQTT-3.1.2-24]
+    client._keepaliveInterval = (this.packet.keepalive * 1500) + 1
+    client._keepaliveTimer = setTimeout(keepaliveTimeout, client._keepaliveInterval)
   }
   done()
 }

--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { pipeline } from 'stream'
 import write from '../write.js'
 import QoSPacket from '../qos-packet.js'
-import { through } from '../utils.js'
+import { runSeries, through } from '../utils.js'
 import handleSubscribe from './subscribe.js'
 
 class Connack {
@@ -86,7 +86,7 @@ function init (client, packet, done) {
   client.version = packet.protocolVersion
   client._will = packet.will
 
-  client.broker._series(
+  runSeries(
     new ClientPacketStatus(client, packet),
     connectActions,
     { returnCode: 0, sessionPresent: false }, // [MQTT-3.1.4-4], [MQTT-3.2.2-4]

--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -61,7 +61,7 @@ function handle (client, packet, done) {
   }
 
   if (client._keepaliveInterval > 0) {
-    client._keepaliveTimer.reschedule(client._keepaliveInterval)
+    client._keepaliveTimer.refresh(client._keepaliveInterval)
   }
 }
 

--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -61,7 +61,7 @@ function handle (client, packet, done) {
   }
 
   if (client._keepaliveInterval > 0) {
-    client._keepaliveTimer.refresh(client._keepaliveInterval)
+    client._keepaliveTimer.refresh()
   }
 }
 

--- a/lib/handlers/publish.js
+++ b/lib/handlers/publish.js
@@ -1,3 +1,4 @@
+import { runSeries } from '../utils.js'
 import write from '../write.js'
 
 class PubAck {
@@ -33,7 +34,7 @@ function handlePublish (client, packet, done) {
     err = new Error('+ is not allowed in PUBLISH')
     return done(err)
   }
-  client.broker._series(client, publishActions, packet, done)
+  runSeries(client, publishActions, packet, done)
 }
 
 function enqueuePublish (packet, done) {

--- a/lib/handlers/pubrel.js
+++ b/lib/handlers/pubrel.js
@@ -1,4 +1,5 @@
 import write from '../write.js'
+import { runSeries } from '../utils.js'
 
 class ClientPacketStatus {
   constructor (client, packet) {
@@ -20,7 +21,7 @@ const pubrelActions = [
   pubrelWrite
 ]
 function handlePubrel (client, packet, done) {
-  client.broker._series(
+  runSeries(
     new ClientPacketStatus(client, packet),
     pubrelActions, {}, done)
 }

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -1,25 +1,6 @@
 import Packet from 'aedes-packet'
-import { through, validateTopic, $SYS_PREFIX } from '../utils.js'
+import { through, validateTopic, $SYS_PREFIX, runFall } from '../utils.js'
 import write from '../write.js'
-
-function runFall (fns) {
-  // run functions in fastfall style, only need the single argument function
-  return function (arg, cb) {
-    let i = 0
-    const ctx = this
-    function next (err, nextarg) {
-      if (err || i === fns.length) {
-        if (typeof cb === 'function') {
-          cb.call(ctx, err, nextarg)
-        }
-        return
-      }
-      const fn = fns[i++]
-      fn.call(ctx, nextarg, next)
-    }
-    next(null, arg)
-  }
-}
 
 const subscribeTopicActions = runFall([
   authorize,

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -81,12 +81,7 @@ async function handleSubscribe (client, packet, restore, done) {
   packet.subscriptions = packet.subscriptions.length === 1 ? packet.subscriptions : _dedupe(packet.subscriptions)
   const state = new SubscribeState(client, packet, restore, done)
   try {
-    await Promise.all(packet.subscriptions.map(sub => new Promise((resolve, reject) => {
-      doSubscribe.call(state, sub, (err, result) => {
-        if (err) reject(err)
-        else resolve(result)
-      })
-    })))
+    await Promise.all(packet.subscriptions.map(sub => doSubscribe(state, sub)))
     if (restore) {
       done()
     } else {
@@ -97,10 +92,15 @@ async function handleSubscribe (client, packet, restore, done) {
   }
 }
 
-function doSubscribe (sub, done) {
-  const s = new SubState(this.client, this.packet, sub.qos, sub.rh, sub.rap, sub.nl)
-  this.subState.push(s)
-  this.actions.call(s, sub, done)
+async function doSubscribe (state, sub) {
+  return new Promise((resolve, reject) => {
+    const s = new SubState(state.client, state.packet, sub.qos, sub.rh, sub.rap, sub.nl)
+    state.subState.push(s)
+    state.actions.call(s, sub, (err, result) => {
+      if (err) reject(err)
+      else resolve(result)
+    })
+  })
 }
 
 function authorize (sub, done) {

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -187,12 +187,15 @@ function addSubs (sub, done) {
     func = blockDollarSignTopics(func)
   }
 
+  /* c8 ignore start */
   if (client.closed || client.broker.closed) {
     // a hack, sometimes client.close() or broker.close() happened
     // before authenticate() comes back
     // we don't continue subscription here
+    // since it is a rare race condition we ignore it in coverage testing
     return
   }
+  /* c8 ignore stop */
 
   if (!client.subscriptions[topic]) {
     client.subscriptions[topic] = new Subscription(qos, func, rh, rap, nl)
@@ -213,13 +216,8 @@ function isStartsWithWildcard (topic) {
   return code === 43 || code === 35
 }
 
-function completeSubscribe (err) {
+function completeSubscribe () {
   const done = this.finish
-
-  if (err) {
-    return done(err)
-  }
-
   const packet = this.packet
   const client = this.client
 

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -1,14 +1,32 @@
-import fastfall from 'fastfall'
 import Packet from 'aedes-packet'
 import { through, validateTopic, $SYS_PREFIX } from '../utils.js'
 import write from '../write.js'
 
-const subscribeTopicActions = fastfall([
+function runFall (fns) {
+  // run functions in fastfall style, only need the single argument function
+  return function (arg, cb) {
+    let i = 0
+    const ctx = this
+    function next (err, nextarg) {
+      if (err || i === fns.length) {
+        if (typeof cb === 'function') {
+          cb.call(ctx, err, nextarg)
+        }
+        return
+      }
+      const fn = fns[i++]
+      fn.call(ctx, nextarg, next)
+    }
+    next(null, arg)
+  }
+}
+
+const subscribeTopicActions = runFall([
   authorize,
   storeSubscriptions,
   addSubs
 ])
-const restoreTopicActions = fastfall([
+const restoreTopicActions = runFall([
   authorize,
   addSubs
 ])
@@ -78,14 +96,24 @@ function _dedupe (subs) {
   return ret
 }
 
-function handleSubscribe (client, packet, restore, done) {
+async function handleSubscribe (client, packet, restore, done) {
   packet.subscriptions = packet.subscriptions.length === 1 ? packet.subscriptions : _dedupe(packet.subscriptions)
-  client.broker._parallel(
-    new SubscribeState(client, packet, restore, done), // what will be this in the functions
-    doSubscribe, // function to call
-    packet.subscriptions, // first argument of the function
-    restore ? done : completeSubscribe // the function to be called when the parallel ends
-  )
+  const state = new SubscribeState(client, packet, restore, done)
+  try {
+    await Promise.all(packet.subscriptions.map(sub => new Promise((resolve, reject) => {
+      doSubscribe.call(state, sub, (err, result) => {
+        if (err) reject(err)
+        else resolve(result)
+      })
+    })))
+    if (restore) {
+      done()
+    } else {
+      completeSubscribe.call(state)
+    }
+  } catch (err) {
+    done(err)
+  }
 }
 
 function doSubscribe (sub, done) {

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -197,8 +197,17 @@ function isStartsWithWildcard (topic) {
   return code === 43 || code === 35
 }
 
+function once (fn) {
+  let called = false
+  return function (err) {
+    if (called) return
+    called = true
+    fn(err)
+  }
+}
+
 function completeSubscribe () {
-  const done = this.finish
+  const done = once(this.finish)
   const packet = this.packet
   const client = this.client
 

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -1,5 +1,5 @@
 import Packet from 'aedes-packet'
-import { through, validateTopic, $SYS_PREFIX, runFall, once } from '../utils.js'
+import { through, validateTopic, $SYS_PREFIX, runFall, runParallel, once } from '../utils.js'
 import write from '../write.js'
 
 const subscribeTopicActions = runFall([
@@ -77,31 +77,28 @@ function _dedupe (subs) {
   return ret
 }
 
-async function handleSubscribe (client, packet, restore, finish) {
+function handleSubscribe (client, packet, restore, finish) {
   const done = once(finish)
   packet.subscriptions = packet.subscriptions.length === 1 ? packet.subscriptions : _dedupe(packet.subscriptions)
   const state = new SubscribeState(client, packet, restore, done)
-  try {
-    await Promise.all(packet.subscriptions.map(sub => doSubscribe(state, sub)))
-    if (restore) {
+  // Use the callback-based runParallel rather than Promise.all(subscriptions.map(...)):
+  // SUBSCRIBE is on the control path and runs once per topic, so avoiding the N+1
+  // promise allocations per packet keeps allocation flat (matches the original fastparallel).
+  runParallel(state, doSubscribe, packet.subscriptions, (err) => {
+    if (err) {
+      done(err)
+    } else if (restore) {
       done()
     } else {
       completeSubscribe.call(state)
     }
-  } catch (err) {
-    done(err)
-  }
+  })
 }
 
-async function doSubscribe (state, sub) {
-  return new Promise((resolve, reject) => {
-    const s = new SubState(state.client, state.packet, sub.qos, sub.rh, sub.rap, sub.nl)
-    state.subState.push(s)
-    state.actions.call(s, sub, (err, result) => {
-      if (err) reject(err)
-      else resolve(result)
-    })
-  })
+function doSubscribe (sub, done) {
+  const s = new SubState(this.client, this.packet, sub.qos, sub.rh, sub.rap, sub.nl)
+  this.subState.push(s)
+  this.actions.call(s, sub, done)
 }
 
 function authorize (sub, done) {

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -1,5 +1,5 @@
 import Packet from 'aedes-packet'
-import { through, validateTopic, $SYS_PREFIX, runFall } from '../utils.js'
+import { through, validateTopic, $SYS_PREFIX, runFall, once } from '../utils.js'
 import write from '../write.js'
 
 const subscribeTopicActions = runFall([
@@ -77,7 +77,8 @@ function _dedupe (subs) {
   return ret
 }
 
-async function handleSubscribe (client, packet, restore, done) {
+async function handleSubscribe (client, packet, restore, finish) {
+  const done = once(finish)
   packet.subscriptions = packet.subscriptions.length === 1 ? packet.subscriptions : _dedupe(packet.subscriptions)
   const state = new SubscribeState(client, packet, restore, done)
   try {
@@ -194,18 +195,8 @@ function isStartsWithWildcard (topic) {
   return code === 43 || code === 35
 }
 
-function once (fn) {
-  let called = false
-  return function (err) {
-    /* c8 ignore next */
-    if (called) return
-    called = true
-    fn(err)
-  }
-}
-
 function completeSubscribe () {
-  const done = once(this.finish)
+  const done = this.finish
   const packet = this.packet
   const client = this.client
 

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -168,15 +168,12 @@ function addSubs (sub, done) {
     func = blockDollarSignTopics(func)
   }
 
-  /* c8 ignore start */
   if (client.closed || client.broker.closed) {
     // a hack, sometimes client.close() or broker.close() happened
     // before authenticate() comes back
     // we don't continue subscription here
-    // since it is a rare race condition we ignore it in coverage testing
     return
   }
-  /* c8 ignore stop */
 
   if (!client.subscriptions[topic]) {
     client.subscriptions[topic] = new Subscription(qos, func, rh, rap, nl)
@@ -200,6 +197,7 @@ function isStartsWithWildcard (topic) {
 function once (fn) {
   let called = false
   return function (err) {
+    /* c8 ignore next */
     if (called) return
     called = true
     fn(err)

--- a/lib/handlers/unsubscribe.js
+++ b/lib/handlers/unsubscribe.js
@@ -43,33 +43,33 @@ function handleUnsubscribe (client, packet, done) {
 async function actualUnsubscribe (client, packet, done) {
   const state = new UnsubscribeState(client, packet, done)
   try {
-    await Promise.all(packet.unsubscriptions.map(sub => new Promise((resolve, reject) => {
-      doUnsubscribe.call(state, sub, (err, result) => {
-        if (err) reject(err)
-        else resolve(result)
-      })
-    })))
+    await Promise.all(packet.unsubscriptions.map(sub => doUnsubscribe(state, sub)))
     completeUnsubscribe.call(state)
   } catch (err) {
     completeUnsubscribe.call(state, err)
   }
 }
 
-function doUnsubscribe (sub, done) {
-  const client = this.client
-  const broker = client.broker
-  const s = client.subscriptions[sub]
+async function doUnsubscribe (state, sub) {
+  return new Promise((resolve, reject) => {
+    const client = state.client
+    const broker = client.broker
+    const s = client.subscriptions[sub]
 
-  if (s) {
-    const func = s.func
-    delete client.subscriptions[sub]
-    broker.unsubscribe(
-      sub,
-      func,
-      done)
-  } else {
-    done()
-  }
+    if (s) {
+      const func = s.func
+      delete client.subscriptions[sub]
+      broker.unsubscribe(
+        sub,
+        func,
+        (err) => {
+          if (err) reject(err)
+          else resolve()
+        })
+    } else {
+      resolve()
+    }
+  })
 }
 
 function completeUnsubscribe (err) {

--- a/lib/handlers/unsubscribe.js
+++ b/lib/handlers/unsubscribe.js
@@ -40,13 +40,19 @@ function handleUnsubscribe (client, packet, done) {
   }
 }
 
-function actualUnsubscribe (client, packet, done) {
-  const broker = client.broker
-  broker._parallel(
-    new UnsubscribeState(client, packet, done),
-    doUnsubscribe,
-    packet.unsubscriptions,
-    completeUnsubscribe)
+async function actualUnsubscribe (client, packet, done) {
+  const state = new UnsubscribeState(client, packet, done)
+  try {
+    await Promise.all(packet.unsubscriptions.map(sub => new Promise((resolve, reject) => {
+      doUnsubscribe.call(state, sub, (err, result) => {
+        if (err) reject(err)
+        else resolve(result)
+      })
+    })))
+    completeUnsubscribe.call(state)
+  } catch (err) {
+    completeUnsubscribe.call(state, err)
+  }
 }
 
 function doUnsubscribe (sub, done) {

--- a/lib/handlers/unsubscribe.js
+++ b/lib/handlers/unsubscribe.js
@@ -58,13 +58,15 @@ async function doUnsubscribe (state, sub) {
 
     if (s) {
       const func = s.func
-      delete client.subscriptions[sub]
       broker.unsubscribe(
         sub,
         func,
         (err) => {
           if (err) reject(err)
-          else resolve()
+          else {
+            delete client.subscriptions[sub]
+            resolve()
+          }
         })
     } else {
       resolve()

--- a/lib/handlers/unsubscribe.js
+++ b/lib/handlers/unsubscribe.js
@@ -1,5 +1,5 @@
 import write from '../write.js'
-import { validateTopic, $SYS_PREFIX, once } from '../utils.js'
+import { validateTopic, $SYS_PREFIX, runParallel, once } from '../utils.js'
 
 class UnSubAck {
   constructor (packet) {
@@ -41,38 +41,36 @@ function handleUnsubscribe (client, packet, finish) {
   }
 }
 
-async function actualUnsubscribe (client, packet, done) {
+function actualUnsubscribe (client, packet, done) {
   const state = new UnsubscribeState(client, packet, done)
-  try {
-    await Promise.all(packet.unsubscriptions.map(sub => doUnsubscribe(state, sub)))
-    completeUnsubscribe.call(state)
-  } catch (err) {
+  // Use the callback-based runParallel instead of Promise.all(unsubscriptions.map(...))
+  // — see subscribe.js: avoids allocating a promise per topic on the control path.
+  runParallel(state, doUnsubscribe, packet.unsubscriptions, (err) => {
     completeUnsubscribe.call(state, err)
-  }
+  })
 }
 
-async function doUnsubscribe (state, sub) {
-  return new Promise((resolve, reject) => {
-    const client = state.client
-    const broker = client.broker
-    const s = client.subscriptions[sub]
+function doUnsubscribe (sub, done) {
+  const client = this.client
+  const broker = client.broker
+  const s = client.subscriptions[sub]
 
-    if (s) {
-      const func = s.func
-      broker.unsubscribe(
-        sub,
-        func,
-        (err) => {
-          if (err) reject(err)
-          else {
-            delete client.subscriptions[sub]
-            resolve()
-          }
-        })
-    } else {
-      resolve()
-    }
-  })
+  if (s) {
+    const func = s.func
+    broker.unsubscribe(
+      sub,
+      func,
+      (err) => {
+        if (err) {
+          done(err)
+        } else {
+          delete client.subscriptions[sub]
+          done()
+        }
+      })
+  } else {
+    done()
+  }
 }
 
 function completeUnsubscribe (err) {

--- a/lib/handlers/unsubscribe.js
+++ b/lib/handlers/unsubscribe.js
@@ -76,14 +76,14 @@ async function doUnsubscribe (state, sub) {
 
 function completeUnsubscribe (err) {
   const client = this.client
+  const done = this.finish
 
   if (err) {
     client.emit('error', err)
-    return
+    return done(err)
   }
 
   const packet = this.packet
-  const done = this.finish
 
   if (packet.messageId !== undefined) {
     write(client, new UnSubAck(packet),

--- a/lib/handlers/unsubscribe.js
+++ b/lib/handlers/unsubscribe.js
@@ -1,5 +1,5 @@
 import write from '../write.js'
-import { validateTopic, $SYS_PREFIX } from '../utils.js'
+import { validateTopic, $SYS_PREFIX, once } from '../utils.js'
 
 class UnSubAck {
   constructor (packet) {
@@ -16,7 +16,8 @@ class UnsubscribeState {
   }
 }
 
-function handleUnsubscribe (client, packet, done) {
+function handleUnsubscribe (client, packet, finish) {
+  const done = once(finish)
   const broker = client.broker
   const unsubscriptions = packet.unsubscriptions
   let err

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -61,7 +61,7 @@ export async function * batch (readable, fn, batchSize) {
   for await (const chunk of readable) {
     chunks.push(fn(chunk))
     if (chunks.length === batchSize) {
-      yield (chunks)
+      yield chunks
       chunks = []
     }
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-import { Transform, Writable } from 'stream'
+import { Transform } from 'stream'
 
 export function validateTopic (topic, message) {
   if (!topic || topic.length === 0) { // [MQTT-3.8.3-3]
@@ -37,16 +37,11 @@ export function through (transform) {
   })
 }
 
-// Nodejs can clear timers in constant time these days
-// https://asafdav2.github.io/2017/node-js-timers/
-// Running retimers bench.js on Node 24.5 shows retimer to be 1 second faster on 1M invocations.
-// hence we can simplify retimer so we don't have to rely on a dependency
 export function retimer (fn, ms) {
-  let timeout = setTimeout(fn, ms)
+  const timeout = setTimeout(fn, ms)
   return {
     reschedule (newMs) {
-      clearTimeout(timeout)
-      timeout = setTimeout(fn, newMs)
+      timeout.refresh(newMs)
     },
     clear () {
       clearTimeout(timeout)
@@ -54,13 +49,19 @@ export function retimer (fn, ms) {
   }
 }
 
-export function bulk (fn) {
-  return new Writable({
-    objectMode: true,
-    writev: function (chunks, cb) {
-      fn(chunks.map(chunk => chunk.chunk), cb)
+export async function * batch (readable, fn, batchSize) {
+  let chunks = []
+  for await (const chunk of readable) {
+    chunks.push(fn(chunk))
+    if (chunks.length === batchSize) {
+      yield (chunks)
+      chunks = []
     }
-  })
+  }
+  // if chunks is half full when the iterator ends
+  if (chunks.length > 0) {
+    yield chunks
+  }
 }
 
 export const $SYS_PREFIX = '$SYS/'

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,7 @@
 import { Transform } from 'stream'
 
+export function noop () { }
+
 export function validateTopic (topic, message) {
   if (!topic || topic.length === 0) { // [MQTT-3.8.3-3]
     return new Error('impossible to ' + message + ' to an empty topic')
@@ -54,6 +56,17 @@ export function runFall (fns) {
     }
     next(null, arg)
   }
+}
+
+export function runSeries (state, actions, packet, done) {
+  // runSeries runs functions in fastseries style
+  done = (done || noop).bind(state)
+  let i = 0
+  function next (err) {
+    if (err || i === actions.length) return done(err)
+    actions[i++].call(state, packet, next)
+  }
+  next()
 }
 
 export async function * batch (readable, fn, batchSize) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,6 +37,40 @@ export function through (transform) {
   })
 }
 
+// DYI object pooling as a replacement for reusify
+export class ObjectPool {
+  constructor (ClassCtor) {
+    this.ClassCtor = ClassCtor
+    this.pool = []
+  }
+
+  get () {
+    return this.pool.pop() || new this.ClassCtor()
+  }
+
+  release (obj) {
+    // Optionally reset the object here if needed
+    this.pool.push(obj)
+  }
+}
+
+// Nodejs can clear timers in constant time these days
+// https://asafdav2.github.io/2017/node-js-timers/
+// Running retimers bench.js on Node 24.5 shows retimer to be 1 second faster on 1M invocations.
+// hence we can simplify retimer so we don't have to rely on a dependency
+export function retimer (fn, ms) {
+  let timeout = setTimeout(fn, ms)
+  return {
+    reschedule (newMs) {
+      clearTimeout(timeout)
+      timeout = setTimeout(fn, newMs)
+    },
+    clear () {
+      clearTimeout(timeout)
+    }
+  }
+}
+
 export function bulk (fn) {
   return new Writable({
     objectMode: true,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,23 +37,6 @@ export function through (transform) {
   })
 }
 
-// DIY object pooling as a replacement for reusify
-export class ObjectPool {
-  constructor (ClassCtor) {
-    this.ClassCtor = ClassCtor
-    this.pool = []
-  }
-
-  get () {
-    return this.pool.pop() || new this.ClassCtor()
-  }
-
-  release (obj) {
-    // Optionally reset the object here if needed
-    this.pool.push(obj)
-  }
-}
-
 // Nodejs can clear timers in constant time these days
 // https://asafdav2.github.io/2017/node-js-timers/
 // Running retimers bench.js on Node 24.5 shows retimer to be 1 second faster on 1M invocations.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,18 +37,6 @@ export function through (transform) {
   })
 }
 
-export function retimer (fn, ms) {
-  const timeout = setTimeout(fn, ms)
-  return {
-    reschedule (newMs) {
-      timeout.refresh(newMs)
-    },
-    clear () {
-      clearTimeout(timeout)
-    }
-  }
-}
-
 export function runFall (fns) {
   // run functions in fastfall style, only need the single argument function
   return function (arg, cb) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,7 +37,7 @@ export function through (transform) {
   })
 }
 
-// DYI object pooling as a replacement for reusify
+// DIY object pooling as a replacement for reusify
 export class ObjectPool {
   constructor (ClassCtor) {
     this.ClassCtor = ClassCtor

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -49,6 +49,25 @@ export function retimer (fn, ms) {
   }
 }
 
+export function runFall (fns) {
+  // run functions in fastfall style, only need the single argument function
+  return function (arg, cb) {
+    let i = 0
+    const ctx = this
+    function next (err, nextarg) {
+      if (err || i === fns.length) {
+        if (typeof cb === 'function') {
+          cb.call(ctx, err, nextarg)
+        }
+        return
+      }
+      const fn = fns[i++]
+      fn.call(ctx, nextarg, next)
+    }
+    next(null, arg)
+  }
+}
+
 export async function * batch (readable, fn, batchSize) {
   let chunks = []
   for await (const chunk of readable) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -69,6 +69,31 @@ export function runSeries (state, actions, packet, done) {
   next()
 }
 
+export function runParallel (state, fn, items, done) {
+  // runParallel runs fn over every item in fastparallel style: fan them all
+  // out concurrently and invoke done once — on the first error, or after all
+  // have completed. Used instead of Promise.all(items.map(...)) so we don't
+  // allocate a promise per item on the (control-path) subscribe/unsubscribe.
+  done = (done || noop).bind(state)
+  let remaining = items.length
+  if (remaining === 0) return done()
+  let finished = false
+  function cb (err) {
+    if (finished) return
+    if (err) {
+      finished = true
+      return done(err)
+    }
+    if (--remaining === 0) {
+      finished = true
+      done()
+    }
+  }
+  for (let i = 0; i < items.length; i++) {
+    fn.call(state, items[i], cb)
+  }
+}
+
 export function once (fn) {
   let called = false
   return function (err) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -69,6 +69,13 @@ export function runSeries (state, actions, packet, done) {
   next()
 }
 
+/**
+ * Async generator that groups items from a readable into batches.
+ * Note: `fn(chunk)` is invoked eagerly for each item in the batch and
+ * the generator yields an array of the results (often promises). Callers
+ * must `await Promise.all(batch)` to apply backpressure before proceeding
+ * to the next yielded batch.
+ */
 export async function * batch (readable, fn, batchSize) {
   let chunks = []
   for await (const chunk of readable) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -72,7 +72,7 @@ export function runSeries (state, actions, packet, done) {
 export function once (fn) {
   let called = false
   return function (err) {
-    /* c8 ignore next */
+    /* c8 ignore next -- guard against double-callback in async error paths */
     if (called) return
     called = true
     fn(err)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -69,6 +69,16 @@ export function runSeries (state, actions, packet, done) {
   next()
 }
 
+export function once (fn) {
+  let called = false
+  return function (err) {
+    /* c8 ignore next */
+    if (called) return
+    called = true
+    fn(err)
+  }
+}
+
 /**
  * Async generator that groups items from a readable into batches.
  * Note: `fn(chunk)` is invoked eagerly for each item in the batch and

--- a/package.json
+++ b/package.json
@@ -120,16 +120,8 @@
 	"dependencies": {
 		"aedes-packet": "^3.0.0",
 		"aedes-persistence": "^10.2.2",
-		"end-of-stream": "^1.4.5",
-		"fastfall": "^1.5.1",
-		"fastparallel": "^2.4.1",
-		"fastseries": "^2.0.0",
-		"hyperid": "^3.3.0",
 		"mqemitter": "^7.1.0",
-		"mqtt-packet": "^9.0.2",
-		"retimer": "^4.0.0",
-		"reusify": "^1.1.0",
-		"uuid": "^11.1.0"
+		"mqtt-packet": "^9.0.2"
 	},
 	"peerDependencies": {
 		"aedes-persistence-level": "^9.1.2",

--- a/test/client-pub-sub.js
+++ b/test/client-pub-sub.js
@@ -7,6 +7,7 @@ import {
   nextPacketWithTimeOut,
   setup,
   subscribe,
+  withTimeout,
 } from './helper.js'
 
 test('publish direct to a single client QoS 0', async (t) => {
@@ -1051,4 +1052,54 @@ test('custom function in broker.unsubscribe', async (t) => {
   const [packet, client] = await once(s.broker, 'publish')
   t.assert.ok(client, 'client exists')
   t.assert.equal(packet.messageId, 42)
+})
+
+// Regression tests for subscribe handling when the client or broker closes
+// before subscription processing completes.
+
+test('ignore subscription when broker closes before addSubs executes', async (t) => {
+  t.plan(3)
+
+  const s = await createAndConnect(t)
+
+  s.broker.authorizeSubscribe = (client, sub, cb) => {
+    setImmediate(() => {
+      s.broker.close()
+      cb(null, sub)
+    })
+  }
+
+  s.inStream.write({
+    cmd: 'subscribe',
+    messageId: 42,
+    subscriptions: [{ topic: 'hello', qos: 0 }]
+  })
+
+  const packet = await withTimeout(nextPacket(s), 50, null)
+  t.assert.equal(packet, null, 'should not receive a suback after broker closes')
+  t.assert.equal(s.broker.closed, true, 'broker is closed')
+  t.assert.equal(s.client.subscriptions.hello, undefined, 'subscription is not stored')
+})
+
+test('ignore subscription when client closes before addSubs executes', async (t) => {
+  t.plan(2)
+
+  const s = await createAndConnect(t)
+
+  s.broker.authorizeSubscribe = (client, sub, cb) => {
+    setImmediate(() => {
+      client.close()
+      cb(null, sub)
+    })
+  }
+
+  s.inStream.write({
+    cmd: 'subscribe',
+    messageId: 43,
+    subscriptions: [{ topic: 'hello', qos: 0 }]
+  })
+
+  const packet = await withTimeout(nextPacket(s), 50, null)
+  t.assert.equal(packet, null, 'should not receive a suback after client closes')
+  t.assert.equal(s.client.subscriptions.hello, undefined, 'subscription is not stored')
 })

--- a/test/client-queue.js
+++ b/test/client-queue.js
@@ -1,0 +1,48 @@
+import { test } from 'node:test'
+import { Aedes } from '../aedes.js'
+import { setup } from './helper.js'
+
+test('client queue limit emits connectionError when publish packets overflow queue', { skip: false }, async (t) => {
+  t.plan(2)
+
+  const queueLimit = 1
+  const broker = await Aedes.createBroker({
+    queueLimit,
+    authenticate (client, username, password, callback) {
+      setTimeout(() => callback(null, true), 50)
+    }
+  })
+  t.after(() => broker.close())
+
+  const publishP = {
+    cmd: 'publish',
+    topic: 'hello',
+    payload: Buffer.from('world'),
+    qos: 0,
+    retain: false
+  }
+
+  const connectP = {
+    cmd: 'connect',
+    protocolId: 'MQTT',
+    protocolVersion: 4,
+    clean: true,
+    clientId: 'abcde',
+    keepalive: 0
+  }
+
+  const s = setup(broker)
+
+  await new Promise((resolve) => {
+    broker.once('connectionError', (client, err) => {
+      t.assert.equal(err.message, 'Client queue limit reached', 'Queue overflow raises connectionError')
+      t.assert.equal(client._parser._queue.length, queueLimit, 'Only queueLimit packets are queued')
+      s.conn.destroy()
+      resolve()
+    })
+
+    s.inStream.write(connectP)
+    s.inStream.write(publishP)
+    s.inStream.write(publishP)
+  })
+})

--- a/test/qos2.js
+++ b/test/qos2.js
@@ -599,3 +599,31 @@ test('send pubcomp when receiving pubrel even if incomingDelPacket throws (no pa
   t.assert.equal(pubcompPacket.cmd, 'pubcomp', 'should send pubcomp')
   t.assert.equal(pubcompPacket.messageId, 42, 'messageId should match')
 })
+
+test('publish QoS 2 returns error when broker.publish fails', async (t) => {
+  t.plan(2)
+
+  const s = await createAndConnect(t)
+  const broker = s.broker
+  const originalPublish = broker.publish.bind(broker)
+
+  broker.publish = function (packet, client, done) {
+    if (packet.topic === 'hello' && packet.qos === 2) {
+      setImmediate(() => done(new Error('boom')))
+      return
+    }
+    return originalPublish(packet, client, done)
+  }
+
+  s.inStream.write({
+    cmd: 'publish',
+    topic: 'hello',
+    payload: 'world',
+    qos: 2,
+    messageId: 42
+  })
+
+  const [client, err] = await once(broker, 'clientError')
+  t.assert.ok(client)
+  t.assert.equal(err.message, 'boom')
+})

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,60 @@
+import { test } from 'node:test'
+import { runFall } from '../lib/utils.js'
+
+test('runFall works ok', function (t) {
+  t.plan(5)
+
+  function a (a, cb) {
+    t.assert.equal(a, 'a', 'first function 1st arg matches')
+    cb(null, 'b')
+  }
+
+  function b (b, cb) {
+    t.assert.equal(b, 'b', 'second function 1st arg matches')
+    cb(null, 'c')
+  }
+
+  function c (c, cb) {
+    t.assert.equal(c, 'c', 'third function 1st arg matches')
+    cb(null, 'd')
+  }
+  function done (err, d) {
+    t.assert.equal(err, null, 'no error')
+    t.assert.equal(d, 'd', 'done argument matches')
+  }
+  const fall = runFall([a, b, c])
+  fall('a', done)
+})
+
+for (let i = 1; i < 4; i++) {
+  test(`runFall with function ${i} returning error`, function (t) {
+    t.plan(1 + i)
+
+    function isErr (n) {
+      if (n === i) {
+        return 'oops'
+      }
+      return null
+    }
+
+    function a (a, cb) {
+      t.assert.equal(a, 'a', 'function a arg matches')
+      cb(isErr(1), 'b')
+    }
+
+    function b (b, cb) {
+      t.assert.equal(b, 'b', 'function b arg matches')
+      cb(isErr(2), 'c')
+    }
+
+    function c (c, cb) {
+      t.assert.equal(c, 'c', 'function c arg matches')
+      cb(isErr(3), 'd')
+    }
+    function done (err, d) {
+      t.assert.equal(err, 'oops')
+    }
+    const fall = runFall([a, b, c])
+    fall('a', done)
+  })
+}

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,5 @@
 import { test } from 'node:test'
-import { runFall, batch } from '../lib/utils.js'
+import { runFall, batch, once, runSeries } from '../lib/utils.js'
 import { setTimeout } from 'timers/promises'
 
 test('runFall works ok', function (t) {
@@ -120,4 +120,156 @@ test('test batch function throwing error', async (t) => {
       resolve()
     })
   })
+})
+
+// Tests for once() function - critical defensive pattern against double-callback
+test('once() prevents double callback invocation', function (t) {
+  t.plan(4)
+
+  let callCount = 0
+  let lastError = null
+
+  function testFn (err) {
+    callCount++
+    lastError = err
+  }
+
+  const wrappedFn = once(testFn)
+
+  const err1 = new Error('first call')
+  wrappedFn(err1)
+  t.assert.equal(callCount, 1, 'callback invoked on first call')
+  t.assert.equal(lastError, err1, 'error passed through on first call')
+
+  const err2 = new Error('second call - should be ignored')
+  wrappedFn(err2)
+  t.assert.equal(callCount, 1, 'callback still invoked only once after second call')
+  t.assert.equal(lastError, err1, 'second error was ignored, first error preserved')
+})
+
+test('once() prevents double callback with null error', function (t) {
+  t.plan(2)
+
+  let callCount = 0
+  const wrappedFn = once(() => { callCount++ })
+
+  wrappedFn(null)
+  t.assert.equal(callCount, 1, 'callback invoked on first call with null')
+
+  wrappedFn(null)
+  t.assert.equal(callCount, 1, 'callback not invoked on second call with null')
+})
+
+// Tests for runSeries() function - critical for sequential handler execution
+test('runSeries executes functions in order', function (t) {
+  t.plan(4)
+
+  const execution = []
+
+  function action1 (packet, next) {
+    execution.push(1)
+    t.assert.equal(execution.length, 1, 'action1 executed first')
+    next()
+  }
+
+  function action2 (packet, next) {
+    execution.push(2)
+    t.assert.equal(execution.length, 2, 'action2 executed second')
+    next()
+  }
+
+  function action3 (packet, next) {
+    execution.push(3)
+    t.assert.equal(execution.length, 3, 'action3 executed third')
+    next()
+  }
+
+  const done = function (err) {
+    if (err) throw err
+    t.assert.deepEqual(execution, [1, 2, 3], 'all actions executed in order')
+  }
+
+  const state = {}
+  runSeries(state, [action1, action2, action3], {}, done)
+})
+
+test('runSeries stops on first error', function (t) {
+  t.plan(3)
+
+  const execution = []
+
+  function action1 (packet, next) {
+    execution.push(1)
+    next()
+  }
+
+  function action2 (packet, next) {
+    execution.push(2)
+    const err = new Error('action2 failed')
+    next(err)
+  }
+
+  function action3 (packet, next) {
+    execution.push(3)
+    next()
+  }
+
+  const done = function (err) {
+    t.assert.equal(err.message, 'action2 failed', 'error from action2 passed to done')
+    t.assert.deepEqual(execution, [1, 2], 'action3 not executed after error')
+    t.assert.equal(execution.length, 2, 'stopped execution at action2')
+  }
+
+  const state = {}
+  runSeries(state, [action1, action2, action3], {}, done)
+})
+
+test('runSeries calls done with no error on success', function (t) {
+  t.plan(2)
+
+  let doneCallCount = 0
+
+  function action1 (packet, next) {
+    next()
+  }
+
+  const done = function (err) {
+    doneCallCount++
+    t.assert.equal(err, undefined, 'done called with no error on success')
+  }
+
+  const state = {}
+  runSeries(state, [action1], {}, done)
+  t.assert.equal(doneCallCount, 1, 'done was called exactly once')
+})
+
+test('runSeries binds this context to actions', function (t) {
+  t.plan(2)
+
+  let contextChecked = false
+
+  function action1 (packet, next) {
+    t.assert.equal(this.clientId, 'test-client', 'this context preserved in action')
+    contextChecked = true
+    next()
+  }
+
+  const done = function (err) {
+    if (err) throw err
+    t.assert.ok(contextChecked, 'action was executed with correct context')
+  }
+
+  const state = { clientId: 'test-client' }
+  runSeries(state, [action1], {}, done)
+})
+
+test('runSeries handles empty actions array', function (t) {
+  t.plan(1)
+
+  const done = function (err) {
+    t.assert.equal(err, undefined, 'done called immediately with no error for empty array')
+  }
+
+  const state = {}
+  runSeries(state, [], {}, done)
 })

--- a/test/utils.js
+++ b/test/utils.js
@@ -93,7 +93,7 @@ for (const [label, numItems, numBatches] of [
   })
 }
 
-test('test batch function trowing error', async (t) => {
+test('test batch function throwing error', async (t) => {
   t.plan(2)
   const numItems = 100
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,5 @@
 import { test } from 'node:test'
-import { runFall, batch, once, runSeries } from '../lib/utils.js'
+import { runFall, batch, once, runSeries, runParallel } from '../lib/utils.js'
 import { setTimeout } from 'timers/promises'
 
 test('runFall works ok', function (t) {
@@ -272,4 +272,81 @@ test('runSeries handles empty actions array', function (t) {
 
   const state = {}
   runSeries(state, [], {}, done)
+})
+
+// Tests for runParallel() function - fastparallel-style fan-out used by subscribe/unsubscribe
+test('runParallel calls done once after all items complete', function (t) {
+  t.plan(3)
+
+  const processed = []
+
+  function action (item, next) {
+    processed.push(item)
+    // resolve asynchronously to exercise the concurrent path
+    setImmediate(next)
+  }
+
+  return new Promise(resolve => {
+    let doneCallCount = 0
+    runParallel({}, action, [1, 2, 3], function (err) {
+      doneCallCount++
+      t.assert.equal(err, undefined, 'done called with no error on success')
+      t.assert.deepEqual(processed.slice().sort(), [1, 2, 3], 'every item was processed')
+      t.assert.equal(doneCallCount, 1, 'done was called exactly once')
+      resolve()
+    })
+  })
+})
+
+test('runParallel stops on first error and ignores later callbacks', function (t) {
+  t.plan(2)
+
+  function action (item, next) {
+    if (item === 2) {
+      return setImmediate(() => next(new Error('item 2 failed')))
+    }
+    setImmediate(next)
+  }
+
+  return new Promise(resolve => {
+    let doneCallCount = 0
+    runParallel({}, action, [1, 2, 3], function (err) {
+      doneCallCount++
+      t.assert.equal(err.message, 'item 2 failed', 'first error passed to done')
+      // wait a tick so any straggler completions would have a chance to re-invoke done
+      setImmediate(() => {
+        t.assert.equal(doneCallCount, 1, 'done called exactly once despite remaining completions')
+        resolve()
+      })
+    })
+  })
+})
+
+test('runParallel binds this context to fn', function (t) {
+  t.plan(2)
+
+  let contextChecked = false
+
+  function action (item, next) {
+    t.assert.equal(this.clientId, 'test-client', 'this context preserved in fn')
+    contextChecked = true
+    next()
+  }
+
+  const done = function (err) {
+    if (err) throw err
+    t.assert.ok(contextChecked, 'fn was executed with correct context')
+  }
+
+  runParallel({ clientId: 'test-client' }, action, [1], done)
+})
+
+test('runParallel handles empty items array', function (t) {
+  t.plan(1)
+
+  const done = function (err) {
+    t.assert.equal(err, undefined, 'done called immediately with no error for empty array')
+  }
+
+  runParallel({}, () => t.assert.fail('fn should not be called'), [], done)
 })


### PR DESCRIPTION
@robertsLando 
As promised, this PR reduces  the number of production dependencies to a bare minimum.

This PR replaces:
1. "end-of-stream" by native "finished" from "node:stream" 
2. "fastfall" by a local  "runfall" 
3. "fastparallel":  by a local "runParallel" 
4. "fastseries": by a local "runSeries" 
5. "hyperid":  by  "randomUUID" from 'node:crypto' , hyperid might be faster (25M ops/second vs 12M ops/second) but also creates predictable ID's and since we only used "hyperid" to generate clientID's  12M ops/second should still be enough imo)
6. "retimer":  by a local  "retimer"  which is nearly as fast as the original "retimer" module with a difference of 1 second on 1M invocations.
7. "reusify": by a local  "ObjectPool"  (btw: reusify was only used on "Enquers" and I am not sure how much performance this actually added as V8 has optimized object creation over time, but just to be sure I put in the ObjectPool)
8. "uuid":  by  "randomUUID" from 'node:crypto' as it turned out that on nodeJS  the "uuidv4" of "uuid"  it is an alias for "randomUUID" from 'node:crypto'  anyway.

The local variants listed above are all quite small, mostly because they only need to support one variant instead of the many variants that some external modules provide. Also over the years some patterns have become more easy to implement with modern Javascript.

This PR tries to keep the code changes to a minimum.
From here on, further optimizations might be possible, but I didn't want to make this PR too complex.

Kind regards,
Hans

 
