### PR TITLE
feat: add `drainTimeout` option to protect against slow/frozen clients

### DIFF
--- a/aedes.js
+++ b/aedes.js
@@ -15,6 +15,7 @@ const defaultOptions = {
   concurrency: 100,
   heartbeatInterval: 60000, // 1 minute
   connectTimeout: 30000, // 30 secs
+  drainTimeout: 0, // disabled by default, set to positive ms to enable
   decodeProtocol: null,
   preConnect: defaultPreConnect,
   authenticate: defaultAuthenticate,

--- a/aedes.js
+++ b/aedes.js
@@ -15,7 +15,7 @@ const defaultOptions = {
   concurrency: 100,
   heartbeatInterval: 60000, // 1 minute
   connectTimeout: 30000, // 30 secs
-  drainTimeout: 0, // disabled by default, set to positive ms to enable
+  drainTimeout: 60000, // 60 secs - protects against slow/frozen clients by default, set to 0 to disable
   decodeProtocol: null,
   preConnect: defaultPreConnect,
   authenticate: defaultAuthenticate,

--- a/docs/Aedes.md
+++ b/docs/Aedes.md
@@ -2,8 +2,8 @@
 # Aedes
 
 - [Aedes](#aedes)
-  - [new Aedes([options])](#new-aedesoptions)
-  - [Aedes.createBroker([options])](#aedescreatebrokeroptions)
+  - [new Aedes(\[options\])](#new-aedesoptions)
+  - [Aedes.createBroker(\[options\])](#aedescreatebrokeroptions)
   - [aedes.listen()](#aedeslisten)
   - [aedes.id](#aedesid)
   - [aedes.connectedClients](#aedesconnectedclients)
@@ -25,7 +25,7 @@
   - [aedes.subscribe (topic, deliverfunc, callback)](#aedessubscribe-topic-deliverfunc-callback)
   - [aedes.unsubscribe (topic, deliverfunc, callback)](#aedesunsubscribe-topic-deliverfunc-callback)
   - [aedes.publish (packet, callback)](#aedespublish-packet-callback)
-  - [aedes.close ([callback])](#aedesclose-callback)
+  - [aedes.close (\[callback\])](#aedesclose-callback)
   - [Handler: preConnect (client, packet, callback)](#handler-preconnect-client-packet-callback)
   - [Handler: authenticate (client, username, password, callback)](#handler-authenticate-client-username-password-callback)
   - [Handler: authorizePublish (client, packet, callback)](#handler-authorizepublish-client-packet-callback)
@@ -48,7 +48,7 @@
   - `id` `<string>` aedes broker unique identifier. __Default__: `uuidv4()`
   - `connectTimeout` `<number>` maximum waiting time in milliseconds waiting for a [`CONNECT`][CONNECT] packet. __Default__: `30000`
   - `keepaliveLimit` `<number>` maximum client keep alive time allowed, 0 means no limit. __Default__: `0`
-  - `drainTimeout` `<number>` maximum time in milliseconds to wait for a slow client's socket to drain before disconnecting it. When a client's socket buffer fills up (e.g., slow network, unresponsive client), the broker waits for the `drain` event. Without a timeout, one slow client can block message delivery to all other clients. Set to a positive value to disconnect slow clients after the timeout. __Default__: `0` (disabled - wait indefinitely)
+  - `drainTimeout` `<number>` maximum time in milliseconds to wait for a slow client's socket to drain before disconnecting it. When a client's socket buffer fills up (e.g., slow network, unresponsive client), the broker waits for the `drain` event. Without a timeout, one slow client can block message delivery to all other clients. Set to `0` to disable and wait indefinitely (not recommended). __Default__: `60000` (60 seconds)
 
     __Why use drainTimeout?__ When publishing messages, if a client's TCP buffer is full, `socket.write()` returns `false` and the broker waits for the `drain` event before continuing. If the client stops reading (slow 3G, crashed app, malicious client), `drain` never fires and that message hangs forever. Even with high `concurrency`, a single frozen subscriber will eventually exhaust all slots and cause __complete deadlock__ - no more messages can be delivered to ANY client. This is a DoS vulnerability.
 
@@ -60,7 +60,8 @@
     ```js
     // Recommended for production
     const broker = await Aedes.createBroker({
-      drainTimeout: 30000  // Disconnect unresponsive clients after 30 seconds
+      drainTimeout: 30000  // Disconnect unresponsive clients after 30 seconds (default: 60000)
+      // drainTimeout: 0   // Disable timeout - NOT RECOMMENDED: vulnerable to DoS
     })
 
     // Monitor disconnections (optional)

--- a/lib/client.js
+++ b/lib/client.js
@@ -330,12 +330,21 @@ class Client {
       this._connectTimer = null
     }
 
-    // Clean up drain timeout timer and pending callbacks
+    // Clean up drain timeout timer, listener, and flush pending callbacks
     if (this._drainTimer) {
       clearTimeout(this._drainTimer)
       this._drainTimer = null
     }
+    if (this._onDrainBound) {
+      this.conn.removeListener('drain', this._onDrainBound)
+    }
+    // Flush pending drain callbacks with connection closed error
+    const error = new Error('connection closed')
+    const pending = this._pendingDrains
     this._pendingDrains = []
+    for (let i = 0; i < pending.length; i++) {
+      setImmediate(pending[i], error, this)
+    }
 
     this._eos()
     this._eos = noop

--- a/lib/client.js
+++ b/lib/client.js
@@ -219,6 +219,88 @@ class Client {
     handleUnsubscribe(this, packet, done)
   }
 
+  /**
+   * Handle successful drain - socket is writable again
+   * Clears timer and completes all pending drain callbacks
+   */
+  _handleDrain () {
+    // Clear the single per-client timer
+    if (this._drainTimer) {
+      clearTimeout(this._drainTimer)
+      this._drainTimer = null
+    }
+
+    // Complete all pending drain callbacks
+    const pending = this._pendingDrains
+    this._pendingDrains = []
+    for (let i = 0; i < pending.length; i++) {
+      setImmediate(pending[i], null, this)
+    }
+  }
+
+  /**
+   * Handle drain timeout - client failed to drain within timeout
+   * Disconnects the client and fails all pending callbacks
+   */
+  _handleDrainTimeout () {
+    this._drainTimer = null
+
+    // Remove drain listener to prevent it firing after disconnect
+    if (this._onDrainBound) {
+      this.conn.removeListener('drain', this._onDrainBound)
+    }
+
+    // Fail all pending callbacks
+    const error = new Error('drain timeout')
+    const pending = this._pendingDrains
+    this._pendingDrains = []
+    for (let i = 0; i < pending.length; i++) {
+      setImmediate(pending[i], error, this)
+    }
+
+    // Disconnect the slow client
+    this.conn.destroy(error)
+  }
+
+  /**
+   * Register a callback to be called when socket drains
+   * Uses per-client coalesced timer to reduce timer overhead
+   * @param {Function} callback - called with (err, client)
+   */
+  waitForDrain (callback) {
+    const drainTimeout = this.broker?.opts?.drainTimeout
+
+    if (drainTimeout > 0) {
+      // Per-client coalesced timer approach:
+      // Only create ONE timer per client, regardless of pending writes
+
+      // Add this callback to pending queue
+      this._pendingDrains.push(callback)
+
+      // If no timer exists, create one and set up drain listener
+      if (!this._drainTimer) {
+        // Create bound drain handler (if not already created)
+        if (!this._onDrainBound) {
+          this._onDrainBound = this._handleDrain.bind(this)
+        }
+
+        // Set up single drain listener
+        this.conn.once('drain', this._onDrainBound)
+
+        // Create single timer for this client
+        this._drainTimer = setTimeout(
+          this._handleDrainTimeout.bind(this),
+          drainTimeout
+        )
+        this._drainTimer.unref() // Don't keep process alive
+      }
+      // else: timer already running, just queued the callback
+    } else {
+      // Without drain timeout: wait indefinitely (original behavior)
+      this.conn.once('drain', callback)
+    }
+  }
+
   close (done) {
     if (this.closed) {
       if (typeof done === 'function') {

--- a/lib/client.js
+++ b/lib/client.js
@@ -39,6 +39,10 @@ class Client {
     this._parsingBatch = 1
     this._nextId = Math.ceil(Math.random() * 65535)
 
+    // Drain timeout tracking - coalesced timer approach
+    this._drainTimer = null
+    this._pendingDrains = []
+
     this.req = req
     this.connDetails = req ? req.connDetails : null
 
@@ -243,6 +247,13 @@ class Client {
       clearTimeout(this._connectTimer)
       this._connectTimer = null
     }
+
+    // Clean up drain timeout timer and pending callbacks
+    if (this._drainTimer) {
+      clearTimeout(this._drainTimer)
+      this._drainTimer = null
+    }
+    this._pendingDrains = []
 
     this._eos()
     this._eos = noop

--- a/lib/write.js
+++ b/lib/write.js
@@ -1,5 +1,46 @@
 import mqtt from 'mqtt-packet'
 
+/**
+ * Handle drain event - called when socket becomes writable again
+ * Clears the timer and completes all pending drain callbacks
+ */
+function onDrain (client) {
+  // Clear the single per-client timer
+  if (client._drainTimer) {
+    clearTimeout(client._drainTimer)
+    client._drainTimer = null
+  }
+
+  // Complete all pending drain callbacks
+  const pending = client._pendingDrains
+  client._pendingDrains = []
+  for (let i = 0; i < pending.length; i++) {
+    setImmediate(pending[i], null, client)
+  }
+}
+
+/**
+ * Handle drain timeout - called when client fails to drain within timeout
+ * Disconnects the client and fails all pending callbacks
+ */
+function onDrainTimeout (client) {
+  client._drainTimer = null
+
+  // Remove drain listener to prevent it firing after disconnect
+  client.conn.removeListener('drain', client._onDrainBound)
+
+  // Fail all pending callbacks
+  const error = new Error('drain timeout')
+  const pending = client._pendingDrains
+  client._pendingDrains = []
+  for (let i = 0; i < pending.length; i++) {
+    setImmediate(pending[i], error, client)
+  }
+
+  // Disconnect the slow client
+  client.conn.destroy(error)
+}
+
 function write (client, packet, done) {
   let error = null
   if (client.connecting || client.connected) {
@@ -8,20 +49,31 @@ function write (client, packet, done) {
       if (!result && !client.errored) {
         const drainTimeout = client.broker?.opts?.drainTimeout
         if (drainTimeout > 0) {
-          // With drain timeout: disconnect slow clients instead of blocking forever
-          const timer = setTimeout(() => {
-            client.conn.removeListener('drain', onDrain)
-            error = new Error('drain timeout')
-            client.conn.destroy(error)
-            setImmediate(done, error, client)
-          }, drainTimeout)
-          timer.unref() // Don't keep process alive for this timer
-          // ? is it safe to have so many timers?
-          function onDrain () {
-            clearTimeout(timer)
-            done(null, client)
+          // Per-client coalesced timer approach:
+          // Only create ONE timer per client, regardless of pending writes
+
+          // Add this callback to pending queue
+          client._pendingDrains.push(done)
+
+          // If no timer exists, create one and set up drain listener
+          if (!client._drainTimer) {
+            // Create bound drain handler (if not already created)
+            if (!client._onDrainBound) {
+              client._onDrainBound = onDrain.bind(null, client)
+            }
+
+            // Set up single drain listener
+            client.conn.once('drain', client._onDrainBound)
+
+            // Create single timer for this client
+            client._drainTimer = setTimeout(
+              onDrainTimeout,
+              drainTimeout,
+              client
+            )
+            client._drainTimer.unref() // Don't keep process alive
           }
-          client.conn.once('drain', onDrain)
+          // else: timer already running, just queued the callback
         } else {
           // Without drain timeout: wait indefinitely (original behavior)
           client.conn.once('drain', done)

--- a/lib/write.js
+++ b/lib/write.js
@@ -1,83 +1,13 @@
 import mqtt from 'mqtt-packet'
 
-/**
- * Handle drain event - called when socket becomes writable again
- * Clears the timer and completes all pending drain callbacks
- */
-function onDrain (client) {
-  // Clear the single per-client timer
-  if (client._drainTimer) {
-    clearTimeout(client._drainTimer)
-    client._drainTimer = null
-  }
-
-  // Complete all pending drain callbacks
-  const pending = client._pendingDrains
-  client._pendingDrains = []
-  for (let i = 0; i < pending.length; i++) {
-    setImmediate(pending[i], null, client)
-  }
-}
-
-/**
- * Handle drain timeout - called when client fails to drain within timeout
- * Disconnects the client and fails all pending callbacks
- */
-function onDrainTimeout (client) {
-  client._drainTimer = null
-
-  // Remove drain listener to prevent it firing after disconnect
-  client.conn.removeListener('drain', client._onDrainBound)
-
-  // Fail all pending callbacks
-  const error = new Error('drain timeout')
-  const pending = client._pendingDrains
-  client._pendingDrains = []
-  for (let i = 0; i < pending.length; i++) {
-    setImmediate(pending[i], error, client)
-  }
-
-  // Disconnect the slow client
-  client.conn.destroy(error)
-}
-
 function write (client, packet, done) {
   let error = null
   if (client.connecting || client.connected) {
     try {
       const result = mqtt.writeToStream(packet, client.conn)
       if (!result && !client.errored) {
-        const drainTimeout = client.broker?.opts?.drainTimeout
-        if (drainTimeout > 0) {
-          // Per-client coalesced timer approach:
-          // Only create ONE timer per client, regardless of pending writes
-
-          // Add this callback to pending queue
-          client._pendingDrains.push(done)
-
-          // If no timer exists, create one and set up drain listener
-          if (!client._drainTimer) {
-            // Create bound drain handler (if not already created)
-            if (!client._onDrainBound) {
-              client._onDrainBound = onDrain.bind(null, client)
-            }
-
-            // Set up single drain listener
-            client.conn.once('drain', client._onDrainBound)
-
-            // Create single timer for this client
-            client._drainTimer = setTimeout(
-              onDrainTimeout,
-              drainTimeout,
-              client
-            )
-            client._drainTimer.unref() // Don't keep process alive
-          }
-          // else: timer already running, just queued the callback
-        } else {
-          // Without drain timeout: wait indefinitely (original behavior)
-          client.conn.once('drain', done)
-        }
+        // Socket buffer is full - wait for drain
+        client.waitForDrain(done)
         return
       }
     } catch (e) {

--- a/lib/write.js
+++ b/lib/write.js
@@ -6,7 +6,26 @@ function write (client, packet, done) {
     try {
       const result = mqtt.writeToStream(packet, client.conn)
       if (!result && !client.errored) {
-        client.conn.once('drain', done)
+        const drainTimeout = client.broker?.opts?.drainTimeout
+        if (drainTimeout > 0) {
+          // With drain timeout: disconnect slow clients instead of blocking forever
+          const timer = setTimeout(() => {
+            client.conn.removeListener('drain', onDrain)
+            error = new Error('drain timeout')
+            client.conn.destroy(error)
+            setImmediate(done, error, client)
+          }, drainTimeout)
+          timer.unref() // Don't keep process alive for this timer
+          // ? is it safe to have so many timers?
+          function onDrain () {
+            clearTimeout(timer)
+            done(null, client)
+          }
+          client.conn.once('drain', onDrain)
+        } else {
+          // Without drain timeout: wait indefinitely (original behavior)
+          client.conn.once('drain', done)
+        }
         return
       }
     } catch (e) {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,8 @@
 		"mqtt": "^5.14.0",
 		"neostandard": "^0.12.2",
 		"release-it": "^19.0.4",
+		"testcontainers": "^11.9.0",
+		"toxiproxy-node-client": "^4.0.0",
 		"tsd": "^0.33.0",
 		"ws": "^8.18.3"
 	},

--- a/test/basic.js
+++ b/test/basic.js
@@ -821,7 +821,7 @@ test('overlapping sub does not double deliver', async (t) => {
 test('clear drain', async (t) => {
   t.plan(5)
 
-  const s = await createAndConnect(t)
+  const s = await createAndConnect(t, { broker: { drainTimeout: 0 } }) // Disable timeout to test old behavior
   await subscribe(t, s, 'hello', 0)
 
   // fake a busy socket

--- a/test/drain-timeout.js
+++ b/test/drain-timeout.js
@@ -16,546 +16,552 @@ import { createServer } from 'node:net'
 import { setTimeout as delay } from 'node:timers/promises'
 import mqtt from 'mqtt'
 import { Aedes } from '../aedes.js'
-import { skipOnWindowsAndMac } from './helper.js'
+import { shouldSkipOnWindowsAndMac } from './helper.js'
 
-// Skip these tests on Windows and macOS (readStop not supported)
-skipOnWindowsAndMac('drain-timeout')
+// Check if we should skip tests on Windows/macOS (readStop not supported)
+const shouldSkip = shouldSkipOnWindowsAndMac()
+if (shouldSkip) {
+  console.log('Skipping drain-timeout tests on Windows/macOS (readStop not supported)')
+}
 
 const { duplexPair } = await import('node:stream')
 const mqttPacket = await import('mqtt-packet')
 
-// ============================================================================
-// UNIT TESTS - Mocked Streams
-// ============================================================================
+// Only run tests if platform is supported
+if (!shouldSkip) {
+  // ============================================================================
+  // UNIT TESTS - Mocked Streams
+  // ============================================================================
 
-/**
- * Helper: Create a mocked MQTT client connection
- */
-function createMockedClient (broker, clientId) {
-  const [clientSide, serverSide] = duplexPair()
+  /**
+   * Helper: Create a mocked MQTT client connection
+   */
+  function createMockedClient (broker, clientId) {
+    const [clientSide, serverSide] = duplexPair()
 
-  // Allow controlling write behavior
-  let blockWrites = false
-  const originalWrite = serverSide.write.bind(serverSide)
+    // Allow controlling write behavior
+    let blockWrites = false
+    const originalWrite = serverSide.write.bind(serverSide)
 
-  serverSide.write = function (chunk, encoding, callback) {
-    if (blockWrites) {
-      // Simulate full buffer - return false and never emit drain
-      return false
+    serverSide.write = function (chunk, encoding, callback) {
+      if (blockWrites) {
+        // Simulate full buffer - return false and never emit drain
+        return false
+      }
+      return originalWrite(chunk, encoding, callback)
     }
-    return originalWrite(chunk, encoding, callback)
+
+    // Track received packets
+    const parser = mqttPacket.parser()
+    const receivedPackets = []
+    parser.on('packet', (packet) => receivedPackets.push(packet))
+    clientSide.on('data', (chunk) => parser.parse(chunk))
+
+    // Track connection state
+    let destroyed = false
+    serverSide.on('close', () => { destroyed = true })
+    serverSide.on('error', () => { destroyed = true })
+
+    broker.handle(serverSide)
+
+    // Send CONNECT
+    clientSide.write(mqttPacket.generate({
+      cmd: 'connect',
+      protocolId: 'MQTT',
+      protocolVersion: 4,
+      clean: true,
+      clientId,
+      keepalive: 0
+    }))
+
+    return {
+      clientSide,
+      serverSide,
+      receivedPackets,
+      setBlocked: (blocked) => { blockWrites = blocked },
+      isDestroyed: () => destroyed,
+      subscribe: (topic) => {
+        clientSide.write(mqttPacket.generate({
+          cmd: 'subscribe',
+          messageId: 1,
+          subscriptions: [{ topic, qos: 0 }]
+        }))
+      },
+      destroy: () => {
+        clientSide.destroy()
+        serverSide.destroy()
+      }
+    }
   }
 
-  // Track received packets
-  const parser = mqttPacket.parser()
-  const receivedPackets = []
-  parser.on('packet', (packet) => receivedPackets.push(packet))
-  clientSide.on('data', (chunk) => parser.parse(chunk))
+  test('UNIT: write.js blocks indefinitely when stream.write returns false', async (t) => {
+    // This test verifies the bug behavior WITHOUT the fix.
+    // When stream.write() returns false and drain never fires,
+    // the broker blocks indefinitely waiting for drain.
 
-  // Track connection state
-  let destroyed = false
-  serverSide.on('close', () => { destroyed = true })
-  serverSide.on('error', () => { destroyed = true })
+    const broker = await Aedes.createBroker({ drainTimeout: 0 }) // No timeout = buggy behavior
+    t.after(() => broker.close())
 
-  broker.handle(serverSide)
+    const client = createMockedClient(broker, 'blocked-client')
+    await delay(50)
+    client.subscribe('test/#')
+    await delay(50)
 
-  // Send CONNECT
-  clientSide.write(mqttPacket.generate({
-    cmd: 'connect',
-    protocolId: 'MQTT',
-    protocolVersion: 4,
-    clean: true,
-    clientId,
-    keepalive: 0
-  }))
+    // Block writes to simulate full buffer
+    client.setBlocked(true)
 
-  return {
-    clientSide,
-    serverSide,
-    receivedPackets,
-    setBlocked: (blocked) => { blockWrites = blocked },
-    isDestroyed: () => destroyed,
-    subscribe: (topic) => {
-      clientSide.write(mqttPacket.generate({
-        cmd: 'subscribe',
-        messageId: 1,
-        subscriptions: [{ topic, qos: 0 }]
-      }))
-    },
-    destroy: () => {
-      clientSide.destroy()
-      serverSide.destroy()
-    }
-  }
-}
+    // Publish - should block forever
+    let publishDone = false
+    const publishPromise = new Promise((resolve) => {
+      broker.publish(
+        { topic: 'test/blocked', payload: Buffer.from('test') },
+        () => {
+          publishDone = true
+          resolve('completed')
+        }
+      )
+    })
 
-test('UNIT: write.js blocks indefinitely when stream.write returns false', async (t) => {
-  // This test verifies the bug behavior WITHOUT the fix.
-  // When stream.write() returns false and drain never fires,
-  // the broker blocks indefinitely waiting for drain.
+    const result = await Promise.race([publishPromise, delay(2000, 'timeout')])
 
-  const broker = await Aedes.createBroker({ drainTimeout: 0 }) // No timeout = buggy behavior
-  t.after(() => broker.close())
+    client.destroy()
 
-  const client = createMockedClient(broker, 'blocked-client')
-  await delay(50)
-  client.subscribe('test/#')
-  await delay(50)
-
-  // Block writes to simulate full buffer
-  client.setBlocked(true)
-
-  // Publish - should block forever
-  let publishDone = false
-  const publishPromise = new Promise((resolve) => {
-    broker.publish(
-      { topic: 'test/blocked', payload: Buffer.from('test') },
-      () => {
-        publishDone = true
-        resolve('completed')
-      }
-    )
+    // STRICT ASSERTION: Must timeout to prove the bug
+    t.assert.strictEqual(result, 'timeout', 'broker must block when write returns false')
+    t.assert.strictEqual(publishDone, false, 'publish callback must not fire')
   })
 
-  const result = await Promise.race([publishPromise, delay(2000, 'timeout')])
+  test('UNIT: drainTimeout disconnects slow client instead of blocking', async (t) => {
+    // This test verifies that with drainTimeout enabled,
+    // the broker disconnects slow clients instead of waiting forever.
 
-  client.destroy()
+    const DRAIN_TIMEOUT_MS = 300
+    const broker = await Aedes.createBroker({ drainTimeout: DRAIN_TIMEOUT_MS })
+    t.after(() => broker.close())
 
-  // STRICT ASSERTION: Must timeout to prove the bug
-  t.assert.strictEqual(result, 'timeout', 'broker must block when write returns false')
-  t.assert.strictEqual(publishDone, false, 'publish callback must not fire')
-})
+    const client = createMockedClient(broker, 'drain-fix-test')
+    await delay(50)
+    client.subscribe('fix/test')
+    await delay(50)
 
-test('UNIT: drainTimeout disconnects slow client instead of blocking', async (t) => {
-  // This test verifies that with drainTimeout enabled,
-  // the broker disconnects slow clients instead of waiting forever.
+    // Verify handshake completed
+    const connack = client.receivedPackets.find(p => p.cmd === 'connack')
+    const suback = client.receivedPackets.find(p => p.cmd === 'suback')
+    t.assert.ok(connack, 'should receive CONNACK')
+    t.assert.ok(suback, 'should receive SUBACK')
 
-  const DRAIN_TIMEOUT_MS = 300
-  const broker = await Aedes.createBroker({ drainTimeout: DRAIN_TIMEOUT_MS })
-  t.after(() => broker.close())
+    // Block writes to simulate backpressure
+    client.setBlocked(true)
 
-  const client = createMockedClient(broker, 'drain-fix-test')
-  await delay(50)
-  client.subscribe('fix/test')
-  await delay(50)
+    // Publish - should complete after drainTimeout kicks the client
+    let publishDone = false
+    const publishPromise = new Promise((resolve) => {
+      broker.publish(
+        { topic: 'fix/test', payload: Buffer.alloc(1024, 'X') },
+        () => {
+          publishDone = true
+          resolve('published')
+        }
+      )
+    })
 
-  // Verify handshake completed
-  const connack = client.receivedPackets.find(p => p.cmd === 'connack')
-  const suback = client.receivedPackets.find(p => p.cmd === 'suback')
-  t.assert.ok(connack, 'should receive CONNACK')
-  t.assert.ok(suback, 'should receive SUBACK')
+    const result = await Promise.race([
+      publishPromise,
+      delay(DRAIN_TIMEOUT_MS + 500, 'timeout')
+    ])
 
-  // Block writes to simulate backpressure
-  client.setBlocked(true)
+    client.destroy()
 
-  // Publish - should complete after drainTimeout kicks the client
-  let publishDone = false
-  const publishPromise = new Promise((resolve) => {
-    broker.publish(
-      { topic: 'fix/test', payload: Buffer.alloc(1024, 'X') },
-      () => {
-        publishDone = true
-        resolve('published')
-      }
-    )
+    // STRICT ASSERTIONS: Fix must work
+    t.assert.strictEqual(result, 'published', 'publish must complete after drain timeout')
+    t.assert.strictEqual(publishDone, true, 'publish callback must fire')
+    t.assert.ok(client.isDestroyed(), 'slow client connection must be destroyed')
   })
 
-  const result = await Promise.race([
-    publishPromise,
-    delay(DRAIN_TIMEOUT_MS + 500, 'timeout')
-  ])
+  test('UNIT: single slow client with concurrency 1 causes deadlock', async (t) => {
+    // With concurrency: 1, one blocked client = complete deadlock
+    // This demonstrates why the fix is critical
 
-  client.destroy()
+    const broker = await Aedes.createBroker({ concurrency: 1, drainTimeout: 0 })
+    t.after(() => broker.close())
 
-  // STRICT ASSERTIONS: Fix must work
-  t.assert.strictEqual(result, 'published', 'publish must complete after drain timeout')
-  t.assert.strictEqual(publishDone, true, 'publish callback must fire')
-  t.assert.ok(client.isDestroyed(), 'slow client connection must be destroyed')
-})
+    const fastClient = createMockedClient(broker, 'fast-1')
+    const slowClient = createMockedClient(broker, 'slow-1')
+    await delay(50)
 
-test('UNIT: single slow client with concurrency 1 causes deadlock', async (t) => {
-  // With concurrency: 1, one blocked client = complete deadlock
-  // This demonstrates why the fix is critical
+    fastClient.subscribe('deadlock/#')
+    slowClient.subscribe('deadlock/#')
+    await delay(50)
 
-  const broker = await Aedes.createBroker({ concurrency: 1, drainTimeout: 0 })
-  t.after(() => broker.close())
+    // Block slow client
+    slowClient.setBlocked(true)
 
-  const fastClient = createMockedClient(broker, 'fast-1')
-  const slowClient = createMockedClient(broker, 'slow-1')
-  await delay(50)
+    // Publish multiple messages
+    let publishCount = 0
+    const NUM_MESSAGES = 5
 
-  fastClient.subscribe('deadlock/#')
-  slowClient.subscribe('deadlock/#')
-  await delay(50)
+    const publishPromise = (async () => {
+      for (let i = 0; i < NUM_MESSAGES; i++) {
+        await new Promise((resolve) => {
+          broker.publish(
+            { topic: 'deadlock/test', payload: Buffer.from(`msg-${i}`) },
+            () => {
+              publishCount++
+              resolve()
+            }
+          )
+        })
+      }
+      return 'done'
+    })()
 
-  // Block slow client
-  slowClient.setBlocked(true)
+    const result = await Promise.race([publishPromise, delay(3000, 'DEADLOCK')])
 
-  // Publish multiple messages
-  let publishCount = 0
-  const NUM_MESSAGES = 5
+    // Count messages fast client received
+    const fastReceived = fastClient.receivedPackets.filter(p => p.cmd === 'publish').length
 
-  const publishPromise = (async () => {
+    fastClient.destroy()
+    slowClient.destroy()
+
+    // STRICT ASSERTIONS: Must deadlock
+    t.assert.strictEqual(result, 'DEADLOCK', 'must deadlock with concurrency 1 and blocked client')
+    t.assert.ok(publishCount < NUM_MESSAGES, `only ${publishCount}/${NUM_MESSAGES} publishes should complete`)
+    t.assert.ok(fastReceived < NUM_MESSAGES, `fast client received ${fastReceived}/${NUM_MESSAGES} - blocked by slow client`)
+  })
+
+  test('UNIT: drainTimeout allows system to recover from deadlock', async (t) => {
+    // With drainTimeout, the slow client gets disconnected and the system recovers
+
+    const DRAIN_TIMEOUT = 200
+    const broker = await Aedes.createBroker({ concurrency: 1, drainTimeout: DRAIN_TIMEOUT })
+    t.after(() => broker.close())
+
+    const fastClient = createMockedClient(broker, 'recovery-fast')
+    const slowClient = createMockedClient(broker, 'recovery-slow')
+    await delay(50)
+
+    fastClient.subscribe('recovery/#')
+    slowClient.subscribe('recovery/#')
+    await delay(50)
+
+    // Block slow client
+    slowClient.setBlocked(true)
+
+    // Publish messages - should complete after slow client is kicked
+    const NUM_MESSAGES = 5
+    let completed = 0
+    const startTime = Date.now()
+
     for (let i = 0; i < NUM_MESSAGES; i++) {
       await new Promise((resolve) => {
         broker.publish(
-          { topic: 'deadlock/test', payload: Buffer.from(`msg-${i}`) },
+          { topic: 'recovery/test', payload: Buffer.from(`msg-${i}`) },
           () => {
-            publishCount++
+            completed++
             resolve()
           }
         )
       })
     }
-    return 'done'
-  })()
 
-  const result = await Promise.race([publishPromise, delay(3000, 'DEADLOCK')])
+    const elapsed = Date.now() - startTime
+    const fastReceived = fastClient.receivedPackets.filter(p => p.cmd === 'publish').length
 
-  // Count messages fast client received
-  const fastReceived = fastClient.receivedPackets.filter(p => p.cmd === 'publish').length
+    fastClient.destroy()
+    slowClient.destroy()
 
-  fastClient.destroy()
-  slowClient.destroy()
+    // STRICT ASSERTIONS: Recovery must work
+    t.assert.strictEqual(completed, NUM_MESSAGES, 'all publishes must complete after recovery')
+    t.assert.ok(slowClient.isDestroyed(), 'slow client must be disconnected')
+    t.assert.ok(fastReceived > 0, `fast client received ${fastReceived} messages after recovery`)
+    t.assert.ok(elapsed >= DRAIN_TIMEOUT, `should take at least ${DRAIN_TIMEOUT}ms for first timeout`)
+  })
 
-  // STRICT ASSERTIONS: Must deadlock
-  t.assert.strictEqual(result, 'DEADLOCK', 'must deadlock with concurrency 1 and blocked client')
-  t.assert.ok(publishCount < NUM_MESSAGES, `only ${publishCount}/${NUM_MESSAGES} publishes should complete`)
-  t.assert.ok(fastReceived < NUM_MESSAGES, `fast client received ${fastReceived}/${NUM_MESSAGES} - blocked by slow client`)
-})
+  // ============================================================================
+  // E2E TESTS - Real TCP with readStop()
+  // ============================================================================
 
-test('UNIT: drainTimeout allows system to recover from deadlock', async (t) => {
-  // With drainTimeout, the slow client gets disconnected and the system recovers
+  /**
+   * RELIABLE APPROACH: readStop()
+   *
+   * Calling socket._handle.readStop() stops libuv from reading at the kernel level.
+   * This causes TCP receive buffer to fill → TCP flow control → sender's send buffer
+   * fills → write() returns false.
+   *
+   * Other approaches that DON'T reliably work on localhost:
+   * - stream.pause() - only pauses Node.js stream, not kernel recv()
+   * - Small highWaterMark - can't change after socket construction
+   * - Transform wrapper - breaks bidirectional communication
+   */
 
-  const DRAIN_TIMEOUT = 200
-  const broker = await Aedes.createBroker({ concurrency: 1, drainTimeout: DRAIN_TIMEOUT })
-  t.after(() => broker.close())
+  test('E2E: readStop() triggers real TCP backpressure', async (t) => {
+    // This test MUST demonstrate backpressure or FAIL
+    // It proves that readStop() reliably triggers write() returning false
 
-  const fastClient = createMockedClient(broker, 'recovery-fast')
-  const slowClient = createMockedClient(broker, 'recovery-slow')
-  await delay(50)
+    const broker = await Aedes.createBroker({ concurrency: 1 })
+    const server = createServer(broker.handle)
 
-  fastClient.subscribe('recovery/#')
-  slowClient.subscribe('recovery/#')
-  await delay(50)
+    let writeReturnedFalse = false
+    let backpressureAtMessage = -1
 
-  // Block slow client
-  slowClient.setBlocked(true)
+    broker.on('client', (client) => {
+      if (client.id === 'e2e-slow') {
+        const origWrite = client.conn.write.bind(client.conn)
+        client.conn.write = function (...args) {
+          const result = origWrite(...args)
+          if (result === false && !writeReturnedFalse) {
+            writeReturnedFalse = true
+          }
+          return result
+        }
+      }
+    })
 
-  // Publish messages - should complete after slow client is kicked
-  const NUM_MESSAGES = 5
-  let completed = 0
-  const startTime = Date.now()
+    t.after(async () => {
+      broker.close()
+      server.close()
+    })
 
-  for (let i = 0; i < NUM_MESSAGES; i++) {
-    await new Promise((resolve) => {
-      broker.publish(
-        { topic: 'recovery/test', payload: Buffer.from(`msg-${i}`) },
-        () => {
-          completed++
+    await new Promise(resolve => server.listen(0, resolve))
+    const port = server.address().port
+
+    // Slow client
+    const slowClient = await mqtt.connectAsync({
+      port,
+      keepalive: 0,
+      clientId: 'e2e-slow'
+    })
+    await slowClient.subscribeAsync('e2e/#')
+
+    // Stop reading at kernel level - THIS IS THE KEY
+    slowClient.stream.pause()
+    if (slowClient.stream._handle && slowClient.stream._handle.readStop) {
+      slowClient.stream._handle.readStop()
+    } else {
+      t.skip('readStop() not available on this platform')
+      return
+    }
+
+    // Publisher
+    const publisher = await mqtt.connectAsync({
+      port,
+      keepalive: 0,
+      clientId: 'e2e-pub'
+    })
+
+    const payload = Buffer.alloc(256 * 1024, 'X') // 256KB
+    const MAX_MESSAGES = 100
+    let sent = 0
+
+    for (let i = 0; i < MAX_MESSAGES; i++) {
+      await new Promise(resolve => {
+        publisher.publish('e2e/test', payload, { qos: 0 }, () => {
+          sent++
           resolve()
-        }
-      )
-    })
-  }
-
-  const elapsed = Date.now() - startTime
-  const fastReceived = fastClient.receivedPackets.filter(p => p.cmd === 'publish').length
-
-  fastClient.destroy()
-  slowClient.destroy()
-
-  // STRICT ASSERTIONS: Recovery must work
-  t.assert.strictEqual(completed, NUM_MESSAGES, 'all publishes must complete after recovery')
-  t.assert.ok(slowClient.isDestroyed(), 'slow client must be disconnected')
-  t.assert.ok(fastReceived > 0, `fast client received ${fastReceived} messages after recovery`)
-  t.assert.ok(elapsed >= DRAIN_TIMEOUT, `should take at least ${DRAIN_TIMEOUT}ms for first timeout`)
-})
-
-// ============================================================================
-// E2E TESTS - Real TCP with readStop()
-// ============================================================================
-
-/**
- * RELIABLE APPROACH: readStop()
- *
- * Calling socket._handle.readStop() stops libuv from reading at the kernel level.
- * This causes TCP receive buffer to fill → TCP flow control → sender's send buffer
- * fills → write() returns false.
- *
- * Other approaches that DON'T reliably work on localhost:
- * - stream.pause() - only pauses Node.js stream, not kernel recv()
- * - Small highWaterMark - can't change after socket construction
- * - Transform wrapper - breaks bidirectional communication
- */
-
-test('E2E: readStop() triggers real TCP backpressure', async (t) => {
-  // This test MUST demonstrate backpressure or FAIL
-  // It proves that readStop() reliably triggers write() returning false
-
-  const broker = await Aedes.createBroker({ concurrency: 1 })
-  const server = createServer(broker.handle)
-
-  let writeReturnedFalse = false
-  let backpressureAtMessage = -1
-
-  broker.on('client', (client) => {
-    if (client.id === 'e2e-slow') {
-      const origWrite = client.conn.write.bind(client.conn)
-      client.conn.write = function (...args) {
-        const result = origWrite(...args)
-        if (result === false && !writeReturnedFalse) {
-          writeReturnedFalse = true
-        }
-        return result
-      }
-    }
-  })
-
-  t.after(async () => {
-    broker.close()
-    server.close()
-  })
-
-  await new Promise(resolve => server.listen(0, resolve))
-  const port = server.address().port
-
-  // Slow client
-  const slowClient = await mqtt.connectAsync({
-    port,
-    keepalive: 0,
-    clientId: 'e2e-slow'
-  })
-  await slowClient.subscribeAsync('e2e/#')
-
-  // Stop reading at kernel level - THIS IS THE KEY
-  slowClient.stream.pause()
-  if (slowClient.stream._handle && slowClient.stream._handle.readStop) {
-    slowClient.stream._handle.readStop()
-  } else {
-    t.skip('readStop() not available on this platform')
-    return
-  }
-
-  // Publisher
-  const publisher = await mqtt.connectAsync({
-    port,
-    keepalive: 0,
-    clientId: 'e2e-pub'
-  })
-
-  const payload = Buffer.alloc(256 * 1024, 'X') // 256KB
-  const MAX_MESSAGES = 100
-  let sent = 0
-
-  for (let i = 0; i < MAX_MESSAGES; i++) {
-    await new Promise(resolve => {
-      publisher.publish('e2e/test', payload, { qos: 0 }, () => {
-        sent++
-        resolve()
+        })
       })
+
+      if (writeReturnedFalse) {
+        backpressureAtMessage = sent
+        break
+      }
+    }
+
+    slowClient.end(true)
+    publisher.end(true)
+
+    // STRICT ASSERTION: This test MUST achieve backpressure
+    t.assert.strictEqual(
+      writeReturnedFalse,
+      true,
+      'readStop() must trigger TCP backpressure'
+    )
+    t.assert.ok(backpressureAtMessage > 0 && backpressureAtMessage < MAX_MESSAGES,
+      `Backpressure should occur before sending all ${MAX_MESSAGES} messages`)
+  })
+
+  test('E2E: drainTimeout disconnects slow client after TCP backpressure', async (t) => {
+    // This test demonstrates the fix with real TCP:
+    // 1. Real backpressure (write() returns false)
+    // 2. drainTimeout kicks in and disconnects slow client
+
+    const DRAIN_TIMEOUT = 500 // Short timeout for faster test
+
+    const broker = await Aedes.createBroker({
+      concurrency: 1,
+      drainTimeout: DRAIN_TIMEOUT
+    })
+    const server = createServer(broker.handle)
+
+    let writeReturnedFalse = false
+    let slowClientDisconnected = false
+
+    broker.on('client', (client) => {
+      if (client.id === 'recovery-slow') {
+        const origWrite = client.conn.write.bind(client.conn)
+        client.conn.write = function (...args) {
+          const result = origWrite(...args)
+          if (result === false && !writeReturnedFalse) {
+            writeReturnedFalse = true
+          }
+          return result
+        }
+      }
     })
 
-    if (writeReturnedFalse) {
-      backpressureAtMessage = sent
-      break
-    }
-  }
-
-  slowClient.end(true)
-  publisher.end(true)
-
-  // STRICT ASSERTION: This test MUST achieve backpressure
-  t.assert.strictEqual(
-    writeReturnedFalse,
-    true,
-    'readStop() must trigger TCP backpressure'
-  )
-  t.assert.ok(backpressureAtMessage > 0 && backpressureAtMessage < MAX_MESSAGES,
-    `Backpressure should occur before sending all ${MAX_MESSAGES} messages`)
-})
-
-test('E2E: drainTimeout disconnects slow client after TCP backpressure', async (t) => {
-  // This test demonstrates the fix with real TCP:
-  // 1. Real backpressure (write() returns false)
-  // 2. drainTimeout kicks in and disconnects slow client
-
-  const DRAIN_TIMEOUT = 500 // Short timeout for faster test
-
-  const broker = await Aedes.createBroker({
-    concurrency: 1,
-    drainTimeout: DRAIN_TIMEOUT
-  })
-  const server = createServer(broker.handle)
-
-  let writeReturnedFalse = false
-  let slowClientDisconnected = false
-
-  broker.on('client', (client) => {
-    if (client.id === 'recovery-slow') {
-      const origWrite = client.conn.write.bind(client.conn)
-      client.conn.write = function (...args) {
-        const result = origWrite(...args)
-        if (result === false && !writeReturnedFalse) {
-          writeReturnedFalse = true
-        }
-        return result
+    broker.on('clientDisconnect', (client) => {
+      if (client.id === 'recovery-slow') {
+        slowClientDisconnected = true
       }
+    })
+
+    t.after(async () => {
+      broker.close()
+      server.close()
+    })
+
+    await new Promise(resolve => server.listen(0, resolve))
+    const port = server.address().port
+
+    // Slow client
+    const slowClient = await mqtt.connectAsync({
+      port,
+      keepalive: 0,
+      clientId: 'recovery-slow'
+    })
+    await slowClient.subscribeAsync('recovery/#')
+
+    // Stop reading at kernel level
+    slowClient.stream.pause()
+    if (slowClient.stream._handle && slowClient.stream._handle.readStop) {
+      slowClient.stream._handle.readStop()
+    } else {
+      t.skip('readStop() not available')
+      return
     }
-  })
 
-  broker.on('clientDisconnect', (client) => {
-    if (client.id === 'recovery-slow') {
-      slowClientDisconnected = true
+    // Publisher
+    const publisher = await mqtt.connectAsync({
+      port,
+      keepalive: 0,
+      clientId: 'recovery-pub'
+    })
+
+    const payload = Buffer.alloc(256 * 1024, 'R')
+    const NUM_MESSAGES = 20
+
+    // Publish to trigger backpressure
+    for (let i = 0; i < NUM_MESSAGES; i++) {
+      publisher.publish('recovery/test', payload, { qos: 0 })
+      if (writeReturnedFalse) break
     }
+
+    // Wait for drainTimeout to fire + margin
+    await delay(DRAIN_TIMEOUT + 200)
+
+    slowClient.end(true)
+    publisher.end(true)
+
+    // STRICT ASSERTIONS
+    t.assert.strictEqual(writeReturnedFalse, true,
+      'Must trigger backpressure for this test to be valid')
+    t.assert.strictEqual(slowClientDisconnected, true,
+      'drainTimeout must disconnect slow client')
   })
 
-  t.after(async () => {
-    broker.close()
-    server.close()
-  })
+  test('E2E: without drainTimeout, slow client impairs system throughput', async (t) => {
+    // This test demonstrates the BUG with real TCP:
+    // Without drainTimeout, a slow client severely impairs message delivery
 
-  await new Promise(resolve => server.listen(0, resolve))
-  const port = server.address().port
+    const broker = await Aedes.createBroker({
+      concurrency: 1,
+      drainTimeout: 0 // Disabled - original buggy behavior
+    })
+    const server = createServer(broker.handle)
 
-  // Slow client
-  const slowClient = await mqtt.connectAsync({
-    port,
-    keepalive: 0,
-    clientId: 'recovery-slow'
-  })
-  await slowClient.subscribeAsync('recovery/#')
+    let writeReturnedFalse = false
 
-  // Stop reading at kernel level
-  slowClient.stream.pause()
-  if (slowClient.stream._handle && slowClient.stream._handle.readStop) {
-    slowClient.stream._handle.readStop()
-  } else {
-    t.skip('readStop() not available')
-    return
-  }
-
-  // Publisher
-  const publisher = await mqtt.connectAsync({
-    port,
-    keepalive: 0,
-    clientId: 'recovery-pub'
-  })
-
-  const payload = Buffer.alloc(256 * 1024, 'R')
-  const NUM_MESSAGES = 20
-
-  // Publish to trigger backpressure
-  for (let i = 0; i < NUM_MESSAGES; i++) {
-    publisher.publish('recovery/test', payload, { qos: 0 })
-    if (writeReturnedFalse) break
-  }
-
-  // Wait for drainTimeout to fire + margin
-  await delay(DRAIN_TIMEOUT + 200)
-
-  slowClient.end(true)
-  publisher.end(true)
-
-  // STRICT ASSERTIONS
-  t.assert.strictEqual(writeReturnedFalse, true,
-    'Must trigger backpressure for this test to be valid')
-  t.assert.strictEqual(slowClientDisconnected, true,
-    'drainTimeout must disconnect slow client')
-})
-
-test('E2E: without drainTimeout, slow client impairs system throughput', async (t) => {
-  // This test demonstrates the BUG with real TCP:
-  // Without drainTimeout, a slow client severely impairs message delivery
-
-  const broker = await Aedes.createBroker({
-    concurrency: 1,
-    drainTimeout: 0 // Disabled - original buggy behavior
-  })
-  const server = createServer(broker.handle)
-
-  let writeReturnedFalse = false
-
-  broker.on('client', (client) => {
-    if (client.id === 'bug-slow') {
-      const origWrite = client.conn.write.bind(client.conn)
-      client.conn.write = function (...args) {
-        const result = origWrite(...args)
-        if (result === false && !writeReturnedFalse) {
-          writeReturnedFalse = true
+    broker.on('client', (client) => {
+      if (client.id === 'bug-slow') {
+        const origWrite = client.conn.write.bind(client.conn)
+        client.conn.write = function (...args) {
+          const result = origWrite(...args)
+          if (result === false && !writeReturnedFalse) {
+            writeReturnedFalse = true
+          }
+          return result
         }
-        return result
       }
+    })
+
+    t.after(async () => {
+      broker.close()
+      server.close()
+    })
+
+    await new Promise(resolve => server.listen(0, resolve))
+    const port = server.address().port
+
+    // Slow client
+    const slowClient = await mqtt.connectAsync({
+      port,
+      keepalive: 0,
+      clientId: 'bug-slow'
+    })
+    await slowClient.subscribeAsync('bug/#')
+
+    // Fast client
+    const fastClient = await mqtt.connectAsync({
+      port,
+      keepalive: 0,
+      clientId: 'bug-fast'
+    })
+    await fastClient.subscribeAsync('bug/#')
+
+    let fastReceived = 0
+    fastClient.on('message', () => { fastReceived++ })
+
+    // Stop slow client from reading
+    slowClient.stream.pause()
+    if (slowClient.stream._handle && slowClient.stream._handle.readStop) {
+      slowClient.stream._handle.readStop()
+    } else {
+      t.skip('readStop() not available')
+      return
     }
+
+    // Publisher
+    const publisher = await mqtt.connectAsync({
+      port,
+      keepalive: 0,
+      clientId: 'bug-pub'
+    })
+
+    const payload = Buffer.alloc(256 * 1024, 'B')
+    const NUM_MESSAGES = 50
+
+    // Send all messages
+    for (let i = 0; i < NUM_MESSAGES; i++) {
+      publisher.publish('bug/test', payload, { qos: 0 })
+    }
+
+    // Wait for delivery attempts
+    await delay(1000)
+
+    slowClient.end(true)
+    fastClient.end(true)
+    publisher.end(true)
+
+    // STRICT ASSERTIONS
+    t.assert.strictEqual(writeReturnedFalse, true,
+      'Must trigger backpressure for this test to be valid')
+
+    // Fast client should NOT receive all messages because slow client blocks
+    t.assert.ok(fastReceived < NUM_MESSAGES,
+      `Fast client should NOT receive all ${NUM_MESSAGES} messages (received ${fastReceived})`)
+
+    // Throughput should be severely degraded (<50%)
+    t.assert.ok(fastReceived < NUM_MESSAGES * 0.5,
+      `Throughput should be severely degraded (<50%), got ${((fastReceived / NUM_MESSAGES) * 100).toFixed(1)}%`)
   })
-
-  t.after(async () => {
-    broker.close()
-    server.close()
-  })
-
-  await new Promise(resolve => server.listen(0, resolve))
-  const port = server.address().port
-
-  // Slow client
-  const slowClient = await mqtt.connectAsync({
-    port,
-    keepalive: 0,
-    clientId: 'bug-slow'
-  })
-  await slowClient.subscribeAsync('bug/#')
-
-  // Fast client
-  const fastClient = await mqtt.connectAsync({
-    port,
-    keepalive: 0,
-    clientId: 'bug-fast'
-  })
-  await fastClient.subscribeAsync('bug/#')
-
-  let fastReceived = 0
-  fastClient.on('message', () => { fastReceived++ })
-
-  // Stop slow client from reading
-  slowClient.stream.pause()
-  if (slowClient.stream._handle && slowClient.stream._handle.readStop) {
-    slowClient.stream._handle.readStop()
-  } else {
-    t.skip('readStop() not available')
-    return
-  }
-
-  // Publisher
-  const publisher = await mqtt.connectAsync({
-    port,
-    keepalive: 0,
-    clientId: 'bug-pub'
-  })
-
-  const payload = Buffer.alloc(256 * 1024, 'B')
-  const NUM_MESSAGES = 50
-
-  // Send all messages
-  for (let i = 0; i < NUM_MESSAGES; i++) {
-    publisher.publish('bug/test', payload, { qos: 0 })
-  }
-
-  // Wait for delivery attempts
-  await delay(1000)
-
-  slowClient.end(true)
-  fastClient.end(true)
-  publisher.end(true)
-
-  // STRICT ASSERTIONS
-  t.assert.strictEqual(writeReturnedFalse, true,
-    'Must trigger backpressure for this test to be valid')
-
-  // Fast client should NOT receive all messages because slow client blocks
-  t.assert.ok(fastReceived < NUM_MESSAGES,
-    `Fast client should NOT receive all ${NUM_MESSAGES} messages (received ${fastReceived})`)
-
-  // Throughput should be severely degraded (<50%)
-  t.assert.ok(fastReceived < NUM_MESSAGES * 0.5,
-    `Throughput should be severely degraded (<50%), got ${((fastReceived / NUM_MESSAGES) * 100).toFixed(1)}%`)
-})
+} // End of if (!shouldSkip)

--- a/test/drain-timeout.js
+++ b/test/drain-timeout.js
@@ -25,7 +25,7 @@ if (shouldSkip) {
 }
 
 const { duplexPair } = await import('node:stream')
-const mqttPacket = await import('mqtt-packet')
+const { default: mqttPacket } = await import('mqtt-packet')
 
 // Only run tests if platform is supported
 if (!shouldSkip) {

--- a/test/drain-timeout.js
+++ b/test/drain-timeout.js
@@ -20,580 +20,574 @@ import { shouldSkipOnWindowsAndMac } from './helper.js'
 
 // Check if we should skip tests on Windows/macOS (readStop not supported)
 const shouldSkip = shouldSkipOnWindowsAndMac()
-if (shouldSkip) {
-  console.log('Skipping drain-timeout tests on Windows/macOS (readStop not supported)')
-}
 
 const { duplexPair } = await import('node:stream')
 const { default: mqttPacket } = await import('mqtt-packet')
 
-// Only run tests if platform is supported
-if (!shouldSkip) {
-  // ============================================================================
-  // UNIT TESTS - Mocked Streams
-  // ============================================================================
+// ============================================================================
+// UNIT TESTS - Mocked Streams
+// ============================================================================
 
-  /**
-   * Helper: Create a mocked MQTT client connection
-   */
-  function createMockedClient (broker, clientId) {
-    const [clientSide, serverSide] = duplexPair()
+/**
+ * Helper: Create a mocked MQTT client connection
+ */
+function createMockedClient (broker, clientId) {
+  const [clientSide, serverSide] = duplexPair()
 
-    // Allow controlling write behavior
-    let blockWrites = false
-    const originalWrite = serverSide.write.bind(serverSide)
+  // Allow controlling write behavior
+  let blockWrites = false
+  const originalWrite = serverSide.write.bind(serverSide)
 
-    serverSide.write = function (chunk, encoding, callback) {
-      if (blockWrites) {
-        // Simulate full buffer - return false and never emit drain
-        return false
-      }
-      return originalWrite(chunk, encoding, callback)
+  serverSide.write = function (chunk, encoding, callback) {
+    if (blockWrites) {
+      // Simulate full buffer - return false and never emit drain
+      return false
     }
-
-    // Track received packets
-    const parser = mqttPacket.parser()
-    const receivedPackets = []
-    parser.on('packet', (packet) => receivedPackets.push(packet))
-    clientSide.on('data', (chunk) => parser.parse(chunk))
-
-    // Track connection state
-    let destroyed = false
-    serverSide.on('close', () => { destroyed = true })
-    serverSide.on('error', () => { destroyed = true })
-
-    broker.handle(serverSide)
-
-    // Send CONNECT
-    clientSide.write(mqttPacket.generate({
-      cmd: 'connect',
-      protocolId: 'MQTT',
-      protocolVersion: 4,
-      clean: true,
-      clientId,
-      keepalive: 0
-    }))
-
-    return {
-      clientSide,
-      serverSide,
-      receivedPackets,
-      setBlocked: (blocked) => { blockWrites = blocked },
-      isDestroyed: () => destroyed,
-      subscribe: (topic) => {
-        clientSide.write(mqttPacket.generate({
-          cmd: 'subscribe',
-          messageId: 1,
-          subscriptions: [{ topic, qos: 0 }]
-        }))
-      },
-      destroy: () => {
-        clientSide.destroy()
-        serverSide.destroy()
-      }
-    }
+    return originalWrite(chunk, encoding, callback)
   }
 
-  test('UNIT: write.js blocks indefinitely when stream.write returns false', async (t) => {
-    // This test verifies the bug behavior WITHOUT the fix.
-    // When stream.write() returns false and drain never fires,
-    // the broker blocks indefinitely waiting for drain.
+  // Track received packets
+  const parser = mqttPacket.parser()
+  const receivedPackets = []
+  parser.on('packet', (packet) => receivedPackets.push(packet))
+  clientSide.on('data', (chunk) => parser.parse(chunk))
 
-    const broker = await Aedes.createBroker({ drainTimeout: 0 }) // No timeout = buggy behavior
-    t.after(() => broker.close())
+  // Track connection state
+  let destroyed = false
+  serverSide.on('close', () => { destroyed = true })
+  serverSide.on('error', () => { destroyed = true })
 
-    const client = createMockedClient(broker, 'blocked-client')
-    await delay(50)
-    client.subscribe('test/#')
-    await delay(50)
+  broker.handle(serverSide)
 
-    // Block writes to simulate full buffer
-    client.setBlocked(true)
+  // Send CONNECT
+  clientSide.write(mqttPacket.generate({
+    cmd: 'connect',
+    protocolId: 'MQTT',
+    protocolVersion: 4,
+    clean: true,
+    clientId,
+    keepalive: 0
+  }))
 
-    // Publish - should block forever
-    let publishDone = false
-    const publishPromise = new Promise((resolve) => {
-      broker.publish(
-        { topic: 'test/blocked', payload: Buffer.from('test') },
-        () => {
-          publishDone = true
-          resolve('completed')
-        }
-      )
-    })
+  return {
+    clientSide,
+    serverSide,
+    receivedPackets,
+    setBlocked: (blocked) => { blockWrites = blocked },
+    isDestroyed: () => destroyed,
+    subscribe: (topic) => {
+      clientSide.write(mqttPacket.generate({
+        cmd: 'subscribe',
+        messageId: 1,
+        subscriptions: [{ topic, qos: 0 }]
+      }))
+    },
+    destroy: () => {
+      clientSide.destroy()
+      serverSide.destroy()
+    }
+  }
+}
 
-    const result = await Promise.race([publishPromise, delay(2000, 'timeout')])
+test('UNIT: write.js blocks indefinitely when stream.write returns false', { skip: shouldSkip }, async (t) => {
+  // This test verifies the bug behavior WITHOUT the fix.
+  // When stream.write() returns false and drain never fires,
+  // the broker blocks indefinitely waiting for drain.
 
-    client.destroy()
+  const broker = await Aedes.createBroker({ drainTimeout: 0 }) // No timeout = buggy behavior
+  t.after(() => broker.close())
 
-    // STRICT ASSERTION: Must timeout to prove the bug
-    t.assert.strictEqual(result, 'timeout', 'broker must block when write returns false')
-    t.assert.strictEqual(publishDone, false, 'publish callback must not fire')
-  })
+  const client = createMockedClient(broker, 'blocked-client')
+  await delay(50)
+  client.subscribe('test/#')
+  await delay(50)
 
-  test('UNIT: drainTimeout disconnects slow client instead of blocking', async (t) => {
-    // This test verifies that with drainTimeout enabled,
-    // the broker disconnects slow clients instead of waiting forever.
+  // Block writes to simulate full buffer
+  client.setBlocked(true)
 
-    const DRAIN_TIMEOUT_MS = 300
-    const broker = await Aedes.createBroker({ drainTimeout: DRAIN_TIMEOUT_MS })
-    t.after(() => broker.close())
-
-    const client = createMockedClient(broker, 'drain-fix-test')
-    await delay(50)
-    client.subscribe('fix/test')
-    await delay(50)
-
-    // Verify handshake completed
-    const connack = client.receivedPackets.find(p => p.cmd === 'connack')
-    const suback = client.receivedPackets.find(p => p.cmd === 'suback')
-    t.assert.ok(connack, 'should receive CONNACK')
-    t.assert.ok(suback, 'should receive SUBACK')
-
-    // Block writes to simulate backpressure
-    client.setBlocked(true)
-
-    // Publish - should complete after drainTimeout kicks the client
-    let publishDone = false
-    const publishPromise = new Promise((resolve) => {
-      broker.publish(
-        { topic: 'fix/test', payload: Buffer.alloc(1024, 'X') },
-        () => {
-          publishDone = true
-          resolve('published')
-        }
-      )
-    })
-
-    const result = await Promise.race([
-      publishPromise,
-      delay(DRAIN_TIMEOUT_MS + 500, 'timeout')
-    ])
-
-    client.destroy()
-
-    // STRICT ASSERTIONS: Fix must work
-    t.assert.strictEqual(result, 'published', 'publish must complete after drain timeout')
-    t.assert.strictEqual(publishDone, true, 'publish callback must fire')
-    t.assert.ok(client.isDestroyed(), 'slow client connection must be destroyed')
-  })
-
-  test('UNIT: single slow client with concurrency 1 causes deadlock', async (t) => {
-    // With concurrency: 1, one blocked client = complete deadlock
-    // This demonstrates why the fix is critical
-
-    const broker = await Aedes.createBroker({ concurrency: 1, drainTimeout: 0 })
-    t.after(() => broker.close())
-
-    const fastClient = createMockedClient(broker, 'fast-1')
-    const slowClient = createMockedClient(broker, 'slow-1')
-    await delay(50)
-
-    fastClient.subscribe('deadlock/#')
-    slowClient.subscribe('deadlock/#')
-    await delay(50)
-
-    // Block slow client
-    slowClient.setBlocked(true)
-
-    // Publish multiple messages
-    let publishCount = 0
-    const NUM_MESSAGES = 5
-
-    const publishPromise = (async () => {
-      for (let i = 0; i < NUM_MESSAGES; i++) {
-        await new Promise((resolve) => {
-          broker.publish(
-            { topic: 'deadlock/test', payload: Buffer.from(`msg-${i}`) },
-            () => {
-              publishCount++
-              resolve()
-            }
-          )
-        })
+  // Publish - should block forever
+  let publishDone = false
+  const publishPromise = new Promise((resolve) => {
+    broker.publish(
+      { topic: 'test/blocked', payload: Buffer.from('test') },
+      () => {
+        publishDone = true
+        resolve('completed')
       }
-      return 'done'
-    })()
-
-    const result = await Promise.race([publishPromise, delay(3000, 'DEADLOCK')])
-
-    // Count messages fast client received
-    const fastReceived = fastClient.receivedPackets.filter(p => p.cmd === 'publish').length
-
-    fastClient.destroy()
-    slowClient.destroy()
-
-    // STRICT ASSERTIONS: Must deadlock
-    t.assert.strictEqual(result, 'DEADLOCK', 'must deadlock with concurrency 1 and blocked client')
-    t.assert.ok(publishCount < NUM_MESSAGES, `only ${publishCount}/${NUM_MESSAGES} publishes should complete`)
-    t.assert.ok(fastReceived < NUM_MESSAGES, `fast client received ${fastReceived}/${NUM_MESSAGES} - blocked by slow client`)
+    )
   })
 
-  test('UNIT: drainTimeout allows system to recover from deadlock', async (t) => {
-    // With drainTimeout, the slow client gets disconnected and the system recovers
+  const result = await Promise.race([publishPromise, delay(2000, 'timeout')])
 
-    const DRAIN_TIMEOUT = 200
-    const broker = await Aedes.createBroker({ concurrency: 1, drainTimeout: DRAIN_TIMEOUT })
-    t.after(() => broker.close())
+  client.destroy()
 
-    const fastClient = createMockedClient(broker, 'recovery-fast')
-    const slowClient = createMockedClient(broker, 'recovery-slow')
-    await delay(50)
+  // STRICT ASSERTION: Must timeout to prove the bug
+  t.assert.strictEqual(result, 'timeout', 'broker must block when write returns false')
+  t.assert.strictEqual(publishDone, false, 'publish callback must not fire')
+})
 
-    fastClient.subscribe('recovery/#')
-    slowClient.subscribe('recovery/#')
-    await delay(50)
+test('UNIT: drainTimeout disconnects slow client instead of blocking', { skip: shouldSkip }, async (t) => {
+  // This test verifies that with drainTimeout enabled,
+  // the broker disconnects slow clients instead of waiting forever.
 
-    // Block slow client
-    slowClient.setBlocked(true)
+  const DRAIN_TIMEOUT_MS = 300
+  const broker = await Aedes.createBroker({ drainTimeout: DRAIN_TIMEOUT_MS })
+  t.after(() => broker.close())
 
-    // Publish messages - should complete after slow client is kicked
-    const NUM_MESSAGES = 5
-    let completed = 0
-    const startTime = Date.now()
+  const client = createMockedClient(broker, 'drain-fix-test')
+  await delay(50)
+  client.subscribe('fix/test')
+  await delay(50)
 
+  // Verify handshake completed
+  const connack = client.receivedPackets.find(p => p.cmd === 'connack')
+  const suback = client.receivedPackets.find(p => p.cmd === 'suback')
+  t.assert.ok(connack, 'should receive CONNACK')
+  t.assert.ok(suback, 'should receive SUBACK')
+
+  // Block writes to simulate backpressure
+  client.setBlocked(true)
+
+  // Publish - should complete after drainTimeout kicks the client
+  let publishDone = false
+  const publishPromise = new Promise((resolve) => {
+    broker.publish(
+      { topic: 'fix/test', payload: Buffer.alloc(1024, 'X') },
+      () => {
+        publishDone = true
+        resolve('published')
+      }
+    )
+  })
+
+  const result = await Promise.race([
+    publishPromise,
+    delay(DRAIN_TIMEOUT_MS + 500, 'timeout')
+  ])
+
+  client.destroy()
+
+  // STRICT ASSERTIONS: Fix must work
+  t.assert.strictEqual(result, 'published', 'publish must complete after drain timeout')
+  t.assert.strictEqual(publishDone, true, 'publish callback must fire')
+  t.assert.ok(client.isDestroyed(), 'slow client connection must be destroyed')
+})
+
+test('UNIT: single slow client with concurrency 1 causes deadlock', { skip: shouldSkip }, async (t) => {
+  // With concurrency: 1, one blocked client = complete deadlock
+  // This demonstrates why the fix is critical
+
+  const broker = await Aedes.createBroker({ concurrency: 1, drainTimeout: 0 })
+  t.after(() => broker.close())
+
+  const fastClient = createMockedClient(broker, 'fast-1')
+  const slowClient = createMockedClient(broker, 'slow-1')
+  await delay(50)
+
+  fastClient.subscribe('deadlock/#')
+  slowClient.subscribe('deadlock/#')
+  await delay(50)
+
+  // Block slow client
+  slowClient.setBlocked(true)
+
+  // Publish multiple messages
+  let publishCount = 0
+  const NUM_MESSAGES = 5
+
+  const publishPromise = (async () => {
     for (let i = 0; i < NUM_MESSAGES; i++) {
       await new Promise((resolve) => {
         broker.publish(
-          { topic: 'recovery/test', payload: Buffer.from(`msg-${i}`) },
+          { topic: 'deadlock/test', payload: Buffer.from(`msg-${i}`) },
           () => {
-            completed++
+            publishCount++
             resolve()
           }
         )
       })
     }
+    return 'done'
+  })()
 
-    const elapsed = Date.now() - startTime
-    const fastReceived = fastClient.receivedPackets.filter(p => p.cmd === 'publish').length
+  const result = await Promise.race([publishPromise, delay(3000, 'DEADLOCK')])
 
-    fastClient.destroy()
-    slowClient.destroy()
+  // Count messages fast client received
+  const fastReceived = fastClient.receivedPackets.filter(p => p.cmd === 'publish').length
 
-    // STRICT ASSERTIONS: Recovery must work
-    t.assert.strictEqual(completed, NUM_MESSAGES, 'all publishes must complete after recovery')
-    t.assert.ok(slowClient.isDestroyed(), 'slow client must be disconnected')
-    t.assert.ok(fastReceived > 0, `fast client received ${fastReceived} messages after recovery`)
-    t.assert.ok(elapsed >= DRAIN_TIMEOUT, `should take at least ${DRAIN_TIMEOUT}ms for first timeout`)
-  })
+  fastClient.destroy()
+  slowClient.destroy()
 
-  // ============================================================================
-  // E2E TESTS - Real TCP with readStop()
-  // ============================================================================
+  // STRICT ASSERTIONS: Must deadlock
+  t.assert.strictEqual(result, 'DEADLOCK', 'must deadlock with concurrency 1 and blocked client')
+  t.assert.ok(publishCount < NUM_MESSAGES, `only ${publishCount}/${NUM_MESSAGES} publishes should complete`)
+  t.assert.ok(fastReceived < NUM_MESSAGES, `fast client received ${fastReceived}/${NUM_MESSAGES} - blocked by slow client`)
+})
 
-  /**
-   * RELIABLE APPROACH: readStop()
-   *
-   * Calling socket._handle.readStop() stops libuv from reading at the kernel level.
-   * This causes TCP receive buffer to fill → TCP flow control → sender's send buffer
-   * fills → write() returns false.
-   *
-   * Other approaches that DON'T reliably work on localhost:
-   * - stream.pause() - only pauses Node.js stream, not kernel recv()
-   * - Small highWaterMark - can't change after socket construction
-   * - Transform wrapper - breaks bidirectional communication
-   */
+test('UNIT: drainTimeout allows system to recover from deadlock', { skip: shouldSkip }, async (t) => {
+  // With drainTimeout, the slow client gets disconnected and the system recovers
 
-  test('E2E: readStop() triggers real TCP backpressure', async (t) => {
-    // This test MUST demonstrate backpressure or FAIL
-    // It proves that readStop() reliably triggers write() returning false
+  const DRAIN_TIMEOUT = 200
+  const broker = await Aedes.createBroker({ concurrency: 1, drainTimeout: DRAIN_TIMEOUT })
+  t.after(() => broker.close())
 
-    const broker = await Aedes.createBroker({ concurrency: 1 })
-    const server = createServer(broker.handle)
+  const fastClient = createMockedClient(broker, 'recovery-fast')
+  const slowClient = createMockedClient(broker, 'recovery-slow')
+  await delay(50)
 
-    let writeReturnedFalse = false
-    let backpressureAtMessage = -1
+  fastClient.subscribe('recovery/#')
+  slowClient.subscribe('recovery/#')
+  await delay(50)
 
-    broker.on('client', (client) => {
-      if (client.id === 'e2e-slow') {
-        const origWrite = client.conn.write.bind(client.conn)
-        client.conn.write = function (...args) {
-          const result = origWrite(...args)
-          if (result === false && !writeReturnedFalse) {
-            writeReturnedFalse = true
-          }
-          return result
-        }
-      }
-    })
+  // Block slow client
+  slowClient.setBlocked(true)
 
-    t.after(async () => {
-      broker.close()
-      server.close()
-    })
+  // Publish messages - should complete after slow client is kicked
+  const NUM_MESSAGES = 5
+  let completed = 0
+  const startTime = Date.now()
 
-    await new Promise(resolve => server.listen(0, resolve))
-    const port = server.address().port
-
-    // Slow client
-    const slowClient = await mqtt.connectAsync({
-      port,
-      keepalive: 0,
-      clientId: 'e2e-slow'
-    })
-    await slowClient.subscribeAsync('e2e/#')
-
-    // Stop reading at kernel level - THIS IS THE KEY
-    slowClient.stream.pause()
-    if (slowClient.stream._handle && slowClient.stream._handle.readStop) {
-      slowClient.stream._handle.readStop()
-    } else {
-      t.skip('readStop() not available on this platform')
-      return
-    }
-
-    // Publisher
-    const publisher = await mqtt.connectAsync({
-      port,
-      keepalive: 0,
-      clientId: 'e2e-pub'
-    })
-
-    const payload = Buffer.alloc(256 * 1024, 'X') // 256KB
-    const MAX_MESSAGES = 100
-    let sent = 0
-
-    for (let i = 0; i < MAX_MESSAGES; i++) {
-      await new Promise(resolve => {
-        publisher.publish('e2e/test', payload, { qos: 0 }, () => {
-          sent++
+  for (let i = 0; i < NUM_MESSAGES; i++) {
+    await new Promise((resolve) => {
+      broker.publish(
+        { topic: 'recovery/test', payload: Buffer.from(`msg-${i}`) },
+        () => {
+          completed++
           resolve()
-        })
-      })
-
-      if (writeReturnedFalse) {
-        backpressureAtMessage = sent
-        break
-      }
-    }
-
-    slowClient.end(true)
-    publisher.end(true)
-
-    // STRICT ASSERTION: This test MUST achieve backpressure
-    t.assert.strictEqual(
-      writeReturnedFalse,
-      true,
-      'readStop() must trigger TCP backpressure'
-    )
-    t.assert.ok(backpressureAtMessage > 0 && backpressureAtMessage < MAX_MESSAGES,
-      `Backpressure should occur before sending all ${MAX_MESSAGES} messages`)
-  })
-
-  test('E2E: drainTimeout disconnects slow client after TCP backpressure', async (t) => {
-    // This test demonstrates the fix with real TCP:
-    // 1. Real backpressure (write() returns false)
-    // 2. drainTimeout kicks in and disconnects slow client
-
-    const DRAIN_TIMEOUT = 500 // Short timeout for faster test
-
-    const broker = await Aedes.createBroker({
-      concurrency: 1,
-      drainTimeout: DRAIN_TIMEOUT
-    })
-    const server = createServer(broker.handle)
-
-    let writeReturnedFalse = false
-    let slowClientDisconnected = false
-
-    broker.on('client', (client) => {
-      if (client.id === 'recovery-slow') {
-        const origWrite = client.conn.write.bind(client.conn)
-        client.conn.write = function (...args) {
-          const result = origWrite(...args)
-          if (result === false && !writeReturnedFalse) {
-            writeReturnedFalse = true
-          }
-          return result
         }
-      }
+      )
     })
+  }
 
-    broker.on('clientDisconnect', (client) => {
-      if (client.id === 'recovery-slow') {
-        slowClientDisconnected = true
-      }
-    })
+  const elapsed = Date.now() - startTime
+  const fastReceived = fastClient.receivedPackets.filter(p => p.cmd === 'publish').length
 
-    t.after(async () => {
-      broker.close()
-      server.close()
-    })
+  fastClient.destroy()
+  slowClient.destroy()
 
-    await new Promise(resolve => server.listen(0, resolve))
-    const port = server.address().port
+  // STRICT ASSERTIONS: Recovery must work
+  t.assert.strictEqual(completed, NUM_MESSAGES, 'all publishes must complete after recovery')
+  t.assert.ok(slowClient.isDestroyed(), 'slow client must be disconnected')
+  t.assert.ok(fastReceived > 0, `fast client received ${fastReceived} messages after recovery`)
+  t.assert.ok(elapsed >= DRAIN_TIMEOUT, `should take at least ${DRAIN_TIMEOUT}ms for first timeout`)
+})
 
-    // Slow client
-    const slowClient = await mqtt.connectAsync({
-      port,
-      keepalive: 0,
-      clientId: 'recovery-slow'
-    })
-    await slowClient.subscribeAsync('recovery/#')
+// ============================================================================
+// E2E TESTS - Real TCP with readStop()
+// ============================================================================
 
-    // Stop reading at kernel level
-    slowClient.stream.pause()
-    if (slowClient.stream._handle && slowClient.stream._handle.readStop) {
-      slowClient.stream._handle.readStop()
-    } else {
-      t.skip('readStop() not available')
-      return
-    }
+/**
+ * RELIABLE APPROACH: readStop()
+ *
+ * Calling socket._handle.readStop() stops libuv from reading at the kernel level.
+ * This causes TCP receive buffer to fill → TCP flow control → sender's send buffer
+ * fills → write() returns false.
+ *
+ * Other approaches that DON'T reliably work on localhost:
+ * - stream.pause() - only pauses Node.js stream, not kernel recv()
+ * - Small highWaterMark - can't change after socket construction
+ * - Transform wrapper - breaks bidirectional communication
+ */
 
-    // Publisher
-    const publisher = await mqtt.connectAsync({
-      port,
-      keepalive: 0,
-      clientId: 'recovery-pub'
-    })
+test('E2E: readStop() triggers real TCP backpressure', { skip: shouldSkip }, async (t) => {
+  // This test MUST demonstrate backpressure or FAIL
+  // It proves that readStop() reliably triggers write() returning false
 
-    const payload = Buffer.alloc(256 * 1024, 'R')
-    const NUM_MESSAGES = 20
+  const broker = await Aedes.createBroker({ concurrency: 1 })
+  const server = createServer(broker.handle)
 
-    // Publish to trigger backpressure
-    for (let i = 0; i < NUM_MESSAGES; i++) {
-      publisher.publish('recovery/test', payload, { qos: 0 })
-      if (writeReturnedFalse) break
-    }
+  let writeReturnedFalse = false
+  let backpressureAtMessage = -1
 
-    // Wait for drainTimeout to fire + margin
-    await delay(DRAIN_TIMEOUT + 200)
-
-    slowClient.end(true)
-    publisher.end(true)
-
-    // STRICT ASSERTIONS
-    t.assert.strictEqual(writeReturnedFalse, true,
-      'Must trigger backpressure for this test to be valid')
-    t.assert.strictEqual(slowClientDisconnected, true,
-      'drainTimeout must disconnect slow client')
-  })
-
-  test('E2E: without drainTimeout, slow client impairs system throughput', async (t) => {
-    // This test demonstrates the BUG with real TCP:
-    // Without drainTimeout, a slow client severely impairs message delivery
-
-    const broker = await Aedes.createBroker({
-      concurrency: 1,
-      drainTimeout: 0 // Disabled - original buggy behavior
-    })
-    const server = createServer(broker.handle)
-
-    let writeReturnedFalse = false
-
-    broker.on('client', (client) => {
-      if (client.id === 'bug-slow') {
-        const origWrite = client.conn.write.bind(client.conn)
-        client.conn.write = function (...args) {
-          const result = origWrite(...args)
-          if (result === false && !writeReturnedFalse) {
-            writeReturnedFalse = true
-          }
-          return result
+  broker.on('client', (client) => {
+    if (client.id === 'e2e-slow') {
+      const origWrite = client.conn.write.bind(client.conn)
+      client.conn.write = function (...args) {
+        const result = origWrite(...args)
+        if (result === false && !writeReturnedFalse) {
+          writeReturnedFalse = true
         }
+        return result
       }
-    })
-
-    t.after(async () => {
-      broker.close()
-      server.close()
-    })
-
-    await new Promise(resolve => server.listen(0, resolve))
-    const port = server.address().port
-
-    // Slow client
-    const slowClient = await mqtt.connectAsync({
-      port,
-      keepalive: 0,
-      clientId: 'bug-slow'
-    })
-    await slowClient.subscribeAsync('bug/#')
-
-    // Fast client
-    const fastClient = await mqtt.connectAsync({
-      port,
-      keepalive: 0,
-      clientId: 'bug-fast'
-    })
-    await fastClient.subscribeAsync('bug/#')
-
-    let fastReceived = 0
-    fastClient.on('message', () => { fastReceived++ })
-
-    // Stop slow client from reading
-    slowClient.stream.pause()
-    if (slowClient.stream._handle && slowClient.stream._handle.readStop) {
-      slowClient.stream._handle.readStop()
-    } else {
-      t.skip('readStop() not available')
-      return
     }
-
-    // Publisher
-    const publisher = await mqtt.connectAsync({
-      port,
-      keepalive: 0,
-      clientId: 'bug-pub'
-    })
-
-    const payload = Buffer.alloc(256 * 1024, 'B')
-    const NUM_MESSAGES = 50
-
-    // Send all messages
-    for (let i = 0; i < NUM_MESSAGES; i++) {
-      publisher.publish('bug/test', payload, { qos: 0 })
-    }
-
-    // Wait for delivery attempts
-    await delay(1000)
-
-    slowClient.end(true)
-    fastClient.end(true)
-    publisher.end(true)
-
-    // STRICT ASSERTIONS
-    t.assert.strictEqual(writeReturnedFalse, true,
-      'Must trigger backpressure for this test to be valid')
-
-    // Fast client should NOT receive all messages because slow client blocks
-    t.assert.ok(fastReceived < NUM_MESSAGES,
-      `Fast client should NOT receive all ${NUM_MESSAGES} messages (received ${fastReceived})`)
-
-    // Throughput should be severely degraded (<50%)
-    t.assert.ok(fastReceived < NUM_MESSAGES * 0.5,
-      `Throughput should be severely degraded (<50%), got ${((fastReceived / NUM_MESSAGES) * 100).toFixed(1)}%`)
   })
 
-  test('close() flushes pending drain callbacks with error', async (t) => {
-    const [client, server] = duplexPair()
-    const broker = new Aedes({ drainTimeout: 5000 })
-    const aedesClient = broker.handle(server)
-
-    // Simulate backpressure by pausing the client socket
-    client.pause()
-
-    let callbackInvoked = false
-    let callbackError = null
-
-    // Register a drain callback
-    aedesClient.waitForDrain((err) => {
-      callbackInvoked = true
-      callbackError = err
-    })
-
-    // Close the client connection while drain is pending
-    aedesClient.close()
-
-    // Wait for callback to be invoked asynchronously
-    await new Promise(resolve => setImmediate(resolve))
-
-    // Verify callback was invoked with connection closed error
-    t.assert.strictEqual(callbackInvoked, true, 'Drain callback should be invoked')
-    t.assert.ok(callbackError, 'Callback should receive an error')
-    t.assert.strictEqual(callbackError.message, 'connection closed',
-      'Error should indicate connection closed')
-
+  t.after(async () => {
     broker.close()
+    server.close()
   })
-} // End of if (!shouldSkip)
+
+  await new Promise(resolve => server.listen(0, resolve))
+  const port = server.address().port
+
+  // Slow client
+  const slowClient = await mqtt.connectAsync({
+    port,
+    keepalive: 0,
+    clientId: 'e2e-slow'
+  })
+  await slowClient.subscribeAsync('e2e/#')
+
+  // Stop reading at kernel level - THIS IS THE KEY
+  slowClient.stream.pause()
+  if (slowClient.stream._handle && slowClient.stream._handle.readStop) {
+    slowClient.stream._handle.readStop()
+  } else {
+    t.skip('readStop() not available on this platform')
+    return
+  }
+
+  // Publisher
+  const publisher = await mqtt.connectAsync({
+    port,
+    keepalive: 0,
+    clientId: 'e2e-pub'
+  })
+
+  const payload = Buffer.alloc(256 * 1024, 'X') // 256KB
+  const MAX_MESSAGES = 100
+  let sent = 0
+
+  for (let i = 0; i < MAX_MESSAGES; i++) {
+    await new Promise(resolve => {
+      publisher.publish('e2e/test', payload, { qos: 0 }, () => {
+        sent++
+        resolve()
+      })
+    })
+
+    if (writeReturnedFalse) {
+      backpressureAtMessage = sent
+      break
+    }
+  }
+
+  slowClient.end(true)
+  publisher.end(true)
+
+  // STRICT ASSERTION: This test MUST achieve backpressure
+  t.assert.strictEqual(
+    writeReturnedFalse,
+    true,
+    'readStop() must trigger TCP backpressure'
+  )
+  t.assert.ok(backpressureAtMessage > 0 && backpressureAtMessage < MAX_MESSAGES,
+    `Backpressure should occur before sending all ${MAX_MESSAGES} messages`)
+})
+
+test('E2E: drainTimeout disconnects slow client after TCP backpressure', { skip: shouldSkip }, async (t) => {
+  // This test demonstrates the fix with real TCP:
+  // 1. Real backpressure (write() returns false)
+  // 2. drainTimeout kicks in and disconnects slow client
+
+  const DRAIN_TIMEOUT = 500 // Short timeout for faster test
+
+  const broker = await Aedes.createBroker({
+    concurrency: 1,
+    drainTimeout: DRAIN_TIMEOUT
+  })
+  const server = createServer(broker.handle)
+
+  let writeReturnedFalse = false
+  let slowClientDisconnected = false
+
+  broker.on('client', (client) => {
+    if (client.id === 'recovery-slow') {
+      const origWrite = client.conn.write.bind(client.conn)
+      client.conn.write = function (...args) {
+        const result = origWrite(...args)
+        if (result === false && !writeReturnedFalse) {
+          writeReturnedFalse = true
+        }
+        return result
+      }
+    }
+  })
+
+  broker.on('clientDisconnect', (client) => {
+    if (client.id === 'recovery-slow') {
+      slowClientDisconnected = true
+    }
+  })
+
+  t.after(async () => {
+    broker.close()
+    server.close()
+  })
+
+  await new Promise(resolve => server.listen(0, resolve))
+  const port = server.address().port
+
+  // Slow client
+  const slowClient = await mqtt.connectAsync({
+    port,
+    keepalive: 0,
+    clientId: 'recovery-slow'
+  })
+  await slowClient.subscribeAsync('recovery/#')
+
+  // Stop reading at kernel level
+  slowClient.stream.pause()
+  if (slowClient.stream._handle && slowClient.stream._handle.readStop) {
+    slowClient.stream._handle.readStop()
+  } else {
+    t.skip('readStop() not available')
+    return
+  }
+
+  // Publisher
+  const publisher = await mqtt.connectAsync({
+    port,
+    keepalive: 0,
+    clientId: 'recovery-pub'
+  })
+
+  const payload = Buffer.alloc(256 * 1024, 'R')
+  const NUM_MESSAGES = 20
+
+  // Publish to trigger backpressure
+  for (let i = 0; i < NUM_MESSAGES; i++) {
+    publisher.publish('recovery/test', payload, { qos: 0 })
+    if (writeReturnedFalse) break
+  }
+
+  // Wait for drainTimeout to fire + margin
+  await delay(DRAIN_TIMEOUT + 200)
+
+  slowClient.end(true)
+  publisher.end(true)
+
+  // STRICT ASSERTIONS
+  t.assert.strictEqual(writeReturnedFalse, true,
+    'Must trigger backpressure for this test to be valid')
+  t.assert.strictEqual(slowClientDisconnected, true,
+    'drainTimeout must disconnect slow client')
+})
+
+test('E2E: without drainTimeout, slow client impairs system throughput', { skip: shouldSkip }, async (t) => {
+  // This test demonstrates the BUG with real TCP:
+  // Without drainTimeout, a slow client severely impairs message delivery
+
+  const broker = await Aedes.createBroker({
+    concurrency: 1,
+    drainTimeout: 0 // Disabled - original buggy behavior
+  })
+  const server = createServer(broker.handle)
+
+  let writeReturnedFalse = false
+
+  broker.on('client', (client) => {
+    if (client.id === 'bug-slow') {
+      const origWrite = client.conn.write.bind(client.conn)
+      client.conn.write = function (...args) {
+        const result = origWrite(...args)
+        if (result === false && !writeReturnedFalse) {
+          writeReturnedFalse = true
+        }
+        return result
+      }
+    }
+  })
+
+  t.after(async () => {
+    broker.close()
+    server.close()
+  })
+
+  await new Promise(resolve => server.listen(0, resolve))
+  const port = server.address().port
+
+  // Slow client
+  const slowClient = await mqtt.connectAsync({
+    port,
+    keepalive: 0,
+    clientId: 'bug-slow'
+  })
+  await slowClient.subscribeAsync('bug/#')
+
+  // Fast client
+  const fastClient = await mqtt.connectAsync({
+    port,
+    keepalive: 0,
+    clientId: 'bug-fast'
+  })
+  await fastClient.subscribeAsync('bug/#')
+
+  let fastReceived = 0
+  fastClient.on('message', () => { fastReceived++ })
+
+  // Stop slow client from reading
+  slowClient.stream.pause()
+  if (slowClient.stream._handle && slowClient.stream._handle.readStop) {
+    slowClient.stream._handle.readStop()
+  } else {
+    t.skip('readStop() not available')
+    return
+  }
+
+  // Publisher
+  const publisher = await mqtt.connectAsync({
+    port,
+    keepalive: 0,
+    clientId: 'bug-pub'
+  })
+
+  const payload = Buffer.alloc(256 * 1024, 'B')
+  const NUM_MESSAGES = 50
+
+  // Send all messages
+  for (let i = 0; i < NUM_MESSAGES; i++) {
+    publisher.publish('bug/test', payload, { qos: 0 })
+  }
+
+  // Wait for delivery attempts
+  await delay(1000)
+
+  slowClient.end(true)
+  fastClient.end(true)
+  publisher.end(true)
+
+  // STRICT ASSERTIONS
+  t.assert.strictEqual(writeReturnedFalse, true,
+    'Must trigger backpressure for this test to be valid')
+
+  // Fast client should NOT receive all messages because slow client blocks
+  t.assert.ok(fastReceived < NUM_MESSAGES,
+    `Fast client should NOT receive all ${NUM_MESSAGES} messages (received ${fastReceived})`)
+
+  // Throughput should be severely degraded (<50%)
+  t.assert.ok(fastReceived < NUM_MESSAGES * 0.5,
+    `Throughput should be severely degraded (<50%), got ${((fastReceived / NUM_MESSAGES) * 100).toFixed(1)}%`)
+})
+
+test('close() flushes pending drain callbacks with error', { skip: shouldSkip }, async (t) => {
+  const [client, server] = duplexPair()
+  const broker = new Aedes({ drainTimeout: 5000 })
+  const aedesClient = broker.handle(server)
+
+  // Simulate backpressure by pausing the client socket
+  client.pause()
+
+  let callbackInvoked = false
+  let callbackError = null
+
+  // Register a drain callback
+  aedesClient.waitForDrain((err) => {
+    callbackInvoked = true
+    callbackError = err
+  })
+
+  // Close the client connection while drain is pending
+  aedesClient.close()
+
+  // Wait for callback to be invoked asynchronously
+  await new Promise(resolve => setImmediate(resolve))
+
+  // Verify callback was invoked with connection closed error
+  t.assert.strictEqual(callbackInvoked, true, 'Drain callback should be invoked')
+  t.assert.ok(callbackError, 'Callback should receive an error')
+  t.assert.strictEqual(callbackError.message, 'connection closed',
+    'Error should indicate connection closed')
+
+  broker.close()
+})

--- a/test/drain-timeout.js
+++ b/test/drain-timeout.js
@@ -16,6 +16,10 @@ import { createServer } from 'node:net'
 import { setTimeout as delay } from 'node:timers/promises'
 import mqtt from 'mqtt'
 import { Aedes } from '../aedes.js'
+import { skipOnWindowsAndMac } from './helper.js'
+
+// Skip these tests on Windows and macOS (readStop not supported)
+skipOnWindowsAndMac('drain-timeout')
 
 const { duplexPair } = await import('node:stream')
 const mqttPacket = await import('mqtt-packet')

--- a/test/drain-timeout.js
+++ b/test/drain-timeout.js
@@ -1,0 +1,557 @@
+/**
+ * Drain Timeout Tests
+ *
+ * Tests for the drainTimeout feature that protects against slow/frozen clients
+ * blocking message delivery to all other subscribers.
+ *
+ * Includes:
+ * - Unit tests with mocked streams (reliable, deterministic)
+ * - E2E tests with real TCP using readStop() (proves the fix works)
+ *
+ * Run: node --test test/drain-timeout.js
+ */
+
+import { test } from 'node:test'
+import { createServer } from 'node:net'
+import { setTimeout as delay } from 'node:timers/promises'
+import mqtt from 'mqtt'
+import { Aedes } from '../aedes.js'
+
+const { duplexPair } = await import('node:stream')
+const mqttPacket = await import('mqtt-packet')
+
+// ============================================================================
+// UNIT TESTS - Mocked Streams
+// ============================================================================
+
+/**
+ * Helper: Create a mocked MQTT client connection
+ */
+function createMockedClient (broker, clientId) {
+  const [clientSide, serverSide] = duplexPair()
+
+  // Allow controlling write behavior
+  let blockWrites = false
+  const originalWrite = serverSide.write.bind(serverSide)
+
+  serverSide.write = function (chunk, encoding, callback) {
+    if (blockWrites) {
+      // Simulate full buffer - return false and never emit drain
+      return false
+    }
+    return originalWrite(chunk, encoding, callback)
+  }
+
+  // Track received packets
+  const parser = mqttPacket.parser()
+  const receivedPackets = []
+  parser.on('packet', (packet) => receivedPackets.push(packet))
+  clientSide.on('data', (chunk) => parser.parse(chunk))
+
+  // Track connection state
+  let destroyed = false
+  serverSide.on('close', () => { destroyed = true })
+  serverSide.on('error', () => { destroyed = true })
+
+  broker.handle(serverSide)
+
+  // Send CONNECT
+  clientSide.write(mqttPacket.generate({
+    cmd: 'connect',
+    protocolId: 'MQTT',
+    protocolVersion: 4,
+    clean: true,
+    clientId,
+    keepalive: 0
+  }))
+
+  return {
+    clientSide,
+    serverSide,
+    receivedPackets,
+    setBlocked: (blocked) => { blockWrites = blocked },
+    isDestroyed: () => destroyed,
+    subscribe: (topic) => {
+      clientSide.write(mqttPacket.generate({
+        cmd: 'subscribe',
+        messageId: 1,
+        subscriptions: [{ topic, qos: 0 }]
+      }))
+    },
+    destroy: () => {
+      clientSide.destroy()
+      serverSide.destroy()
+    }
+  }
+}
+
+test('UNIT: write.js blocks indefinitely when stream.write returns false', async (t) => {
+  // This test verifies the bug behavior WITHOUT the fix.
+  // When stream.write() returns false and drain never fires,
+  // the broker blocks indefinitely waiting for drain.
+
+  const broker = await Aedes.createBroker({ drainTimeout: 0 }) // No timeout = buggy behavior
+  t.after(() => broker.close())
+
+  const client = createMockedClient(broker, 'blocked-client')
+  await delay(50)
+  client.subscribe('test/#')
+  await delay(50)
+
+  // Block writes to simulate full buffer
+  client.setBlocked(true)
+
+  // Publish - should block forever
+  let publishDone = false
+  const publishPromise = new Promise((resolve) => {
+    broker.publish(
+      { topic: 'test/blocked', payload: Buffer.from('test') },
+      () => {
+        publishDone = true
+        resolve('completed')
+      }
+    )
+  })
+
+  const result = await Promise.race([publishPromise, delay(2000, 'timeout')])
+
+  client.destroy()
+
+  // STRICT ASSERTION: Must timeout to prove the bug
+  t.assert.strictEqual(result, 'timeout', 'broker must block when write returns false')
+  t.assert.strictEqual(publishDone, false, 'publish callback must not fire')
+})
+
+test('UNIT: drainTimeout disconnects slow client instead of blocking', async (t) => {
+  // This test verifies that with drainTimeout enabled,
+  // the broker disconnects slow clients instead of waiting forever.
+
+  const DRAIN_TIMEOUT_MS = 300
+  const broker = await Aedes.createBroker({ drainTimeout: DRAIN_TIMEOUT_MS })
+  t.after(() => broker.close())
+
+  const client = createMockedClient(broker, 'drain-fix-test')
+  await delay(50)
+  client.subscribe('fix/test')
+  await delay(50)
+
+  // Verify handshake completed
+  const connack = client.receivedPackets.find(p => p.cmd === 'connack')
+  const suback = client.receivedPackets.find(p => p.cmd === 'suback')
+  t.assert.ok(connack, 'should receive CONNACK')
+  t.assert.ok(suback, 'should receive SUBACK')
+
+  // Block writes to simulate backpressure
+  client.setBlocked(true)
+
+  // Publish - should complete after drainTimeout kicks the client
+  let publishDone = false
+  const publishPromise = new Promise((resolve) => {
+    broker.publish(
+      { topic: 'fix/test', payload: Buffer.alloc(1024, 'X') },
+      () => {
+        publishDone = true
+        resolve('published')
+      }
+    )
+  })
+
+  const result = await Promise.race([
+    publishPromise,
+    delay(DRAIN_TIMEOUT_MS + 500, 'timeout')
+  ])
+
+  client.destroy()
+
+  // STRICT ASSERTIONS: Fix must work
+  t.assert.strictEqual(result, 'published', 'publish must complete after drain timeout')
+  t.assert.strictEqual(publishDone, true, 'publish callback must fire')
+  t.assert.ok(client.isDestroyed(), 'slow client connection must be destroyed')
+})
+
+test('UNIT: single slow client with concurrency 1 causes deadlock', async (t) => {
+  // With concurrency: 1, one blocked client = complete deadlock
+  // This demonstrates why the fix is critical
+
+  const broker = await Aedes.createBroker({ concurrency: 1, drainTimeout: 0 })
+  t.after(() => broker.close())
+
+  const fastClient = createMockedClient(broker, 'fast-1')
+  const slowClient = createMockedClient(broker, 'slow-1')
+  await delay(50)
+
+  fastClient.subscribe('deadlock/#')
+  slowClient.subscribe('deadlock/#')
+  await delay(50)
+
+  // Block slow client
+  slowClient.setBlocked(true)
+
+  // Publish multiple messages
+  let publishCount = 0
+  const NUM_MESSAGES = 5
+
+  const publishPromise = (async () => {
+    for (let i = 0; i < NUM_MESSAGES; i++) {
+      await new Promise((resolve) => {
+        broker.publish(
+          { topic: 'deadlock/test', payload: Buffer.from(`msg-${i}`) },
+          () => {
+            publishCount++
+            resolve()
+          }
+        )
+      })
+    }
+    return 'done'
+  })()
+
+  const result = await Promise.race([publishPromise, delay(3000, 'DEADLOCK')])
+
+  // Count messages fast client received
+  const fastReceived = fastClient.receivedPackets.filter(p => p.cmd === 'publish').length
+
+  fastClient.destroy()
+  slowClient.destroy()
+
+  // STRICT ASSERTIONS: Must deadlock
+  t.assert.strictEqual(result, 'DEADLOCK', 'must deadlock with concurrency 1 and blocked client')
+  t.assert.ok(publishCount < NUM_MESSAGES, `only ${publishCount}/${NUM_MESSAGES} publishes should complete`)
+  t.assert.ok(fastReceived < NUM_MESSAGES, `fast client received ${fastReceived}/${NUM_MESSAGES} - blocked by slow client`)
+})
+
+test('UNIT: drainTimeout allows system to recover from deadlock', async (t) => {
+  // With drainTimeout, the slow client gets disconnected and the system recovers
+
+  const DRAIN_TIMEOUT = 200
+  const broker = await Aedes.createBroker({ concurrency: 1, drainTimeout: DRAIN_TIMEOUT })
+  t.after(() => broker.close())
+
+  const fastClient = createMockedClient(broker, 'recovery-fast')
+  const slowClient = createMockedClient(broker, 'recovery-slow')
+  await delay(50)
+
+  fastClient.subscribe('recovery/#')
+  slowClient.subscribe('recovery/#')
+  await delay(50)
+
+  // Block slow client
+  slowClient.setBlocked(true)
+
+  // Publish messages - should complete after slow client is kicked
+  const NUM_MESSAGES = 5
+  let completed = 0
+  const startTime = Date.now()
+
+  for (let i = 0; i < NUM_MESSAGES; i++) {
+    await new Promise((resolve) => {
+      broker.publish(
+        { topic: 'recovery/test', payload: Buffer.from(`msg-${i}`) },
+        () => {
+          completed++
+          resolve()
+        }
+      )
+    })
+  }
+
+  const elapsed = Date.now() - startTime
+  const fastReceived = fastClient.receivedPackets.filter(p => p.cmd === 'publish').length
+
+  fastClient.destroy()
+  slowClient.destroy()
+
+  // STRICT ASSERTIONS: Recovery must work
+  t.assert.strictEqual(completed, NUM_MESSAGES, 'all publishes must complete after recovery')
+  t.assert.ok(slowClient.isDestroyed(), 'slow client must be disconnected')
+  t.assert.ok(fastReceived > 0, `fast client received ${fastReceived} messages after recovery`)
+  t.assert.ok(elapsed >= DRAIN_TIMEOUT, `should take at least ${DRAIN_TIMEOUT}ms for first timeout`)
+})
+
+// ============================================================================
+// E2E TESTS - Real TCP with readStop()
+// ============================================================================
+
+/**
+ * RELIABLE APPROACH: readStop()
+ *
+ * Calling socket._handle.readStop() stops libuv from reading at the kernel level.
+ * This causes TCP receive buffer to fill → TCP flow control → sender's send buffer
+ * fills → write() returns false.
+ *
+ * Other approaches that DON'T reliably work on localhost:
+ * - stream.pause() - only pauses Node.js stream, not kernel recv()
+ * - Small highWaterMark - can't change after socket construction
+ * - Transform wrapper - breaks bidirectional communication
+ */
+
+test('E2E: readStop() triggers real TCP backpressure', async (t) => {
+  // This test MUST demonstrate backpressure or FAIL
+  // It proves that readStop() reliably triggers write() returning false
+
+  const broker = await Aedes.createBroker({ concurrency: 1 })
+  const server = createServer(broker.handle)
+
+  let writeReturnedFalse = false
+  let backpressureAtMessage = -1
+
+  broker.on('client', (client) => {
+    if (client.id === 'e2e-slow') {
+      const origWrite = client.conn.write.bind(client.conn)
+      client.conn.write = function (...args) {
+        const result = origWrite(...args)
+        if (result === false && !writeReturnedFalse) {
+          writeReturnedFalse = true
+        }
+        return result
+      }
+    }
+  })
+
+  t.after(async () => {
+    broker.close()
+    server.close()
+  })
+
+  await new Promise(resolve => server.listen(0, resolve))
+  const port = server.address().port
+
+  // Slow client
+  const slowClient = await mqtt.connectAsync({
+    port,
+    keepalive: 0,
+    clientId: 'e2e-slow'
+  })
+  await slowClient.subscribeAsync('e2e/#')
+
+  // Stop reading at kernel level - THIS IS THE KEY
+  slowClient.stream.pause()
+  if (slowClient.stream._handle && slowClient.stream._handle.readStop) {
+    slowClient.stream._handle.readStop()
+  } else {
+    t.skip('readStop() not available on this platform')
+    return
+  }
+
+  // Publisher
+  const publisher = await mqtt.connectAsync({
+    port,
+    keepalive: 0,
+    clientId: 'e2e-pub'
+  })
+
+  const payload = Buffer.alloc(256 * 1024, 'X') // 256KB
+  const MAX_MESSAGES = 100
+  let sent = 0
+
+  for (let i = 0; i < MAX_MESSAGES; i++) {
+    await new Promise(resolve => {
+      publisher.publish('e2e/test', payload, { qos: 0 }, () => {
+        sent++
+        resolve()
+      })
+    })
+
+    if (writeReturnedFalse) {
+      backpressureAtMessage = sent
+      break
+    }
+  }
+
+  slowClient.end(true)
+  publisher.end(true)
+
+  // STRICT ASSERTION: This test MUST achieve backpressure
+  t.assert.strictEqual(
+    writeReturnedFalse,
+    true,
+    'readStop() must trigger TCP backpressure'
+  )
+  t.assert.ok(backpressureAtMessage > 0 && backpressureAtMessage < MAX_MESSAGES,
+    `Backpressure should occur before sending all ${MAX_MESSAGES} messages`)
+})
+
+test('E2E: drainTimeout disconnects slow client after TCP backpressure', async (t) => {
+  // This test demonstrates the fix with real TCP:
+  // 1. Real backpressure (write() returns false)
+  // 2. drainTimeout kicks in and disconnects slow client
+
+  const DRAIN_TIMEOUT = 500 // Short timeout for faster test
+
+  const broker = await Aedes.createBroker({
+    concurrency: 1,
+    drainTimeout: DRAIN_TIMEOUT
+  })
+  const server = createServer(broker.handle)
+
+  let writeReturnedFalse = false
+  let slowClientDisconnected = false
+
+  broker.on('client', (client) => {
+    if (client.id === 'recovery-slow') {
+      const origWrite = client.conn.write.bind(client.conn)
+      client.conn.write = function (...args) {
+        const result = origWrite(...args)
+        if (result === false && !writeReturnedFalse) {
+          writeReturnedFalse = true
+        }
+        return result
+      }
+    }
+  })
+
+  broker.on('clientDisconnect', (client) => {
+    if (client.id === 'recovery-slow') {
+      slowClientDisconnected = true
+    }
+  })
+
+  t.after(async () => {
+    broker.close()
+    server.close()
+  })
+
+  await new Promise(resolve => server.listen(0, resolve))
+  const port = server.address().port
+
+  // Slow client
+  const slowClient = await mqtt.connectAsync({
+    port,
+    keepalive: 0,
+    clientId: 'recovery-slow'
+  })
+  await slowClient.subscribeAsync('recovery/#')
+
+  // Stop reading at kernel level
+  slowClient.stream.pause()
+  if (slowClient.stream._handle && slowClient.stream._handle.readStop) {
+    slowClient.stream._handle.readStop()
+  } else {
+    t.skip('readStop() not available')
+    return
+  }
+
+  // Publisher
+  const publisher = await mqtt.connectAsync({
+    port,
+    keepalive: 0,
+    clientId: 'recovery-pub'
+  })
+
+  const payload = Buffer.alloc(256 * 1024, 'R')
+  const NUM_MESSAGES = 20
+
+  // Publish to trigger backpressure
+  for (let i = 0; i < NUM_MESSAGES; i++) {
+    publisher.publish('recovery/test', payload, { qos: 0 })
+    if (writeReturnedFalse) break
+  }
+
+  // Wait for drainTimeout to fire + margin
+  await delay(DRAIN_TIMEOUT + 200)
+
+  slowClient.end(true)
+  publisher.end(true)
+
+  // STRICT ASSERTIONS
+  t.assert.strictEqual(writeReturnedFalse, true,
+    'Must trigger backpressure for this test to be valid')
+  t.assert.strictEqual(slowClientDisconnected, true,
+    'drainTimeout must disconnect slow client')
+})
+
+test('E2E: without drainTimeout, slow client impairs system throughput', async (t) => {
+  // This test demonstrates the BUG with real TCP:
+  // Without drainTimeout, a slow client severely impairs message delivery
+
+  const broker = await Aedes.createBroker({
+    concurrency: 1,
+    drainTimeout: 0 // Disabled - original buggy behavior
+  })
+  const server = createServer(broker.handle)
+
+  let writeReturnedFalse = false
+
+  broker.on('client', (client) => {
+    if (client.id === 'bug-slow') {
+      const origWrite = client.conn.write.bind(client.conn)
+      client.conn.write = function (...args) {
+        const result = origWrite(...args)
+        if (result === false && !writeReturnedFalse) {
+          writeReturnedFalse = true
+        }
+        return result
+      }
+    }
+  })
+
+  t.after(async () => {
+    broker.close()
+    server.close()
+  })
+
+  await new Promise(resolve => server.listen(0, resolve))
+  const port = server.address().port
+
+  // Slow client
+  const slowClient = await mqtt.connectAsync({
+    port,
+    keepalive: 0,
+    clientId: 'bug-slow'
+  })
+  await slowClient.subscribeAsync('bug/#')
+
+  // Fast client
+  const fastClient = await mqtt.connectAsync({
+    port,
+    keepalive: 0,
+    clientId: 'bug-fast'
+  })
+  await fastClient.subscribeAsync('bug/#')
+
+  let fastReceived = 0
+  fastClient.on('message', () => { fastReceived++ })
+
+  // Stop slow client from reading
+  slowClient.stream.pause()
+  if (slowClient.stream._handle && slowClient.stream._handle.readStop) {
+    slowClient.stream._handle.readStop()
+  } else {
+    t.skip('readStop() not available')
+    return
+  }
+
+  // Publisher
+  const publisher = await mqtt.connectAsync({
+    port,
+    keepalive: 0,
+    clientId: 'bug-pub'
+  })
+
+  const payload = Buffer.alloc(256 * 1024, 'B')
+  const NUM_MESSAGES = 50
+
+  // Send all messages
+  for (let i = 0; i < NUM_MESSAGES; i++) {
+    publisher.publish('bug/test', payload, { qos: 0 })
+  }
+
+  // Wait for delivery attempts
+  await delay(1000)
+
+  slowClient.end(true)
+  fastClient.end(true)
+  publisher.end(true)
+
+  // STRICT ASSERTIONS
+  t.assert.strictEqual(writeReturnedFalse, true,
+    'Must trigger backpressure for this test to be valid')
+
+  // Fast client should NOT receive all messages because slow client blocks
+  t.assert.ok(fastReceived < NUM_MESSAGES,
+    `Fast client should NOT receive all ${NUM_MESSAGES} messages (received ${fastReceived})`)
+
+  // Throughput should be severely degraded (<50%)
+  t.assert.ok(fastReceived < NUM_MESSAGES * 0.5,
+    `Throughput should be severely degraded (<50%), got ${((fastReceived / NUM_MESSAGES) * 100).toFixed(1)}%`)
+})

--- a/test/drain-toxiproxy.js
+++ b/test/drain-toxiproxy.js
@@ -1,0 +1,615 @@
+/**
+ * ToxiProxy Integration Tests for Drain Timeout
+ *
+ * These tests demonstrate behavior with TRULY SLOW clients (not frozen),
+ * which is different from readStop()-based tests.
+ *
+ * KEY INSIGHT: ToxiProxy simulates slow network, not frozen client.
+ * - Slow client: data IS flowing, just slowly. Messages eventually arrive.
+ * - Frozen client (readStop): data stops entirely. Messages never arrive.
+ *
+ * FINDING: With bandwidth throttling, TCP backpressure occurs after ~1-2MB
+ * (not 25MB as initially suspected). The exact threshold depends on:
+ * - TCP socket buffer sizes (typically 64KB-256KB)
+ * - ToxiProxy's internal buffering
+ * - Bandwidth toxic settings
+ *
+ * What ToxiProxy CAN reveal:
+ * 1. Slow clients DO receive messages (eventually) - no deadlock without backpressure
+ * 2. Large data volumes + bandwidth limits DO trigger TCP backpressure
+ * 3. QoS 1 with latency shows acknowledgment delays
+ * 4. drainTimeout works with proxy-induced backpressure
+ *
+ * These tests require Docker to be running.
+ *
+ * Run: node --test test/drain-toxiproxy.js
+ */
+
+import { test, before, after, describe } from 'node:test'
+import { createServer } from 'node:net'
+import { setTimeout as delay } from 'node:timers/promises'
+import mqtt from 'mqtt'
+import { GenericContainer, Wait } from 'testcontainers'
+import { Toxiproxy } from 'toxiproxy-node-client'
+import { Aedes } from '../aedes.js'
+
+// ToxiProxy configuration
+const TOXIPROXY_API_PORT = 8474
+const PROXY_LISTEN_PORT = 14883
+
+let toxiproxyContainer
+let toxiproxy
+let proxyHost
+let proxyApiPort
+let proxyMappedPort
+
+describe('ToxiProxy: realistic slow client behavior', async () => {
+  before(async () => {
+    console.log('[Setup] Starting ToxiProxy container...')
+
+    toxiproxyContainer = await new GenericContainer('ghcr.io/shopify/toxiproxy:2.9.0')
+      .withExposedPorts(TOXIPROXY_API_PORT, PROXY_LISTEN_PORT)
+      .withCommand(['-host=0.0.0.0'])
+      .withWaitStrategy(Wait.forHttp('/version', TOXIPROXY_API_PORT))
+      .withResourcesQuota({ cpu: 0.5, memory: 256 * 1024 * 1024 })
+      .start()
+
+    proxyHost = toxiproxyContainer.getHost()
+    proxyApiPort = toxiproxyContainer.getMappedPort(TOXIPROXY_API_PORT)
+    proxyMappedPort = toxiproxyContainer.getMappedPort(PROXY_LISTEN_PORT)
+
+    toxiproxy = new Toxiproxy(`http://${proxyHost}:${proxyApiPort}`)
+
+    console.log(`[Setup] ToxiProxy ready at ${proxyHost}:${proxyApiPort}`)
+    console.log(`[Setup] Proxy port mapped: ${PROXY_LISTEN_PORT} -> ${proxyMappedPort}`)
+  })
+
+  after(async () => {
+    if (toxiproxyContainer) {
+      console.log('[Cleanup] Stopping ToxiProxy container...')
+      await toxiproxyContainer.stop()
+    }
+  })
+
+  test('INSIGHT: slow client (via ToxiProxy) vs frozen client (readStop) behavior', async (t) => {
+    // This test demonstrates the KEY DIFFERENCE between slow and frozen clients:
+    // - SLOW client (ToxiProxy): Data flows slowly. Messages eventually arrive.
+    //   No TCP backpressure until ToxiProxy's ~25MB buffer fills.
+    // - FROZEN client (readStop): No data flow. Immediate TCP backpressure.
+    //   Messages never arrive.
+    //
+    // This distinction matters for drainTimeout configuration!
+
+    const broker = await Aedes.createBroker({ concurrency: 1 })
+    const server = createServer(broker.handle)
+    await new Promise(resolve => server.listen(0, '0.0.0.0', resolve))
+    const brokerPort = server.address().port
+
+    const hostIp = process.platform === 'darwin' ? 'host.docker.internal' : '172.17.0.1'
+
+    const proxy = await toxiproxy.createProxy({
+      name: 'aedes-slow-vs-frozen',
+      listen: `0.0.0.0:${PROXY_LISTEN_PORT}`,
+      upstream: `${hostIp}:${brokerPort}`
+    })
+
+    // Slicer: 500 bytes/20ms = ~25KB/s (slow but functional)
+    await proxy.addToxic({
+      name: 'slicer-slow',
+      type: 'slicer',
+      stream: 'downstream',
+      toxicity: 1,
+      attributes: {
+        average_size: 500,
+        size_variation: 50,
+        delay: 20000 // 20ms per chunk
+      }
+    })
+
+    console.log('[Test] Testing SLOW client behavior (~25KB/s throughput)')
+
+    try {
+      const subscriber = await mqtt.connectAsync({
+        host: proxyHost,
+        port: proxyMappedPort,
+        keepalive: 0,
+        clientId: 'slow-subscriber'
+      })
+      await subscriber.subscribeAsync('test/#', { qos: 0 })
+
+      let messagesReceived = 0
+      subscriber.on('message', () => {
+        messagesReceived++
+        console.log(`[Test] Slow client received message ${messagesReceived}`)
+      })
+
+      const publisher = await mqtt.connectAsync({
+        port: brokerPort,
+        keepalive: 0,
+        clientId: 'publisher'
+      })
+
+      // Send small messages to see them arrive slowly
+      const payload = Buffer.alloc(4 * 1024, 'S') // 4KB - arrives in ~160ms
+      const numMessages = 5
+
+      console.log(`[Test] Publishing ${numMessages} x 4KB messages...`)
+      const startTime = Date.now()
+
+      for (let i = 0; i < numMessages; i++) {
+        publisher.publish('test/topic', payload, { qos: 0 })
+      }
+
+      // Wait for slow delivery (4KB at 25KB/s = 160ms per message, + buffer time)
+      console.log('[Test] Waiting for slow delivery...')
+      await delay(3000) // 3 seconds should be enough for 5 messages
+
+      const elapsed = Date.now() - startTime
+
+      console.log(`[Test] Elapsed: ${elapsed}ms`)
+      console.log(`[Test] Messages received: ${messagesReceived}/${numMessages}`)
+
+      // KEY INSIGHT: Unlike frozen client, slow client DOES receive messages!
+      // This is the crucial difference ToxiProxy reveals.
+      t.assert.ok(messagesReceived > 0, 'Slow client DOES receive messages (unlike frozen client)')
+      t.assert.ok(messagesReceived >= numMessages - 1, 'Most/all messages should arrive given enough time')
+
+      console.log('[Test] SUCCESS: Slow client received messages (no deadlock)')
+      console.log('[Test] This is DIFFERENT from frozen client where messages never arrive!')
+
+      subscriber.end(true)
+      publisher.end(true)
+    } finally {
+      await proxy.remove()
+      broker.close()
+      server.close()
+    }
+  })
+
+  test('limit_data toxic: client freezes mid-stream, drainTimeout disconnects it', async (t) => {
+    // limit_data stops forwarding after N bytes - simulates a client that freezes.
+    // With drainTimeout enabled, the broker should disconnect the frozen client.
+    // Without drainTimeout, the broker would wait forever (but ToxiProxy buffers mask this).
+
+    const DRAIN_TIMEOUT = 1000
+
+    const broker = await Aedes.createBroker({
+      concurrency: 1,
+      drainTimeout: DRAIN_TIMEOUT
+    })
+    const server = createServer(broker.handle)
+    await new Promise(resolve => server.listen(0, '0.0.0.0', resolve))
+    const brokerPort = server.address().port
+
+    const hostIp = process.platform === 'darwin' ? 'host.docker.internal' : '172.17.0.1'
+
+    const proxy = await toxiproxy.createProxy({
+      name: 'aedes-limit-test',
+      listen: `0.0.0.0:${PROXY_LISTEN_PORT}`,
+      upstream: `${hostIp}:${brokerPort}`
+    })
+
+    // Allow MQTT handshake, then freeze after 5KB downstream
+    await proxy.addToxic({
+      name: 'limit-down',
+      type: 'limit_data',
+      stream: 'downstream',
+      toxicity: 1,
+      attributes: {
+        bytes: 5 * 1024 // Freeze after 5KB sent to client
+      }
+    })
+
+    console.log('[Test] limit_data: connection freezes after 5KB downstream')
+    console.log(`[Test] drainTimeout: ${DRAIN_TIMEOUT}ms`)
+
+    let clientDisconnected = false
+
+    try {
+      const subscriber = await mqtt.connectAsync({
+        host: proxyHost,
+        port: proxyMappedPort,
+        keepalive: 0,
+        clientId: 'frozen-client'
+      })
+      await subscriber.subscribeAsync('freeze/#', { qos: 0 })
+
+      let messagesReceived = 0
+      subscriber.on('message', () => { messagesReceived++ })
+      subscriber.on('close', () => {
+        clientDisconnected = true
+        console.log('[Test] Frozen client disconnected')
+      })
+
+      const publisher = await mqtt.connectAsync({
+        port: brokerPort,
+        keepalive: 0,
+        clientId: 'freeze-publisher'
+      })
+
+      // Send enough data to exceed the 5KB limit and trigger freeze
+      const payload = Buffer.alloc(32 * 1024, 'F') // 32KB > 5KB limit
+
+      console.log('[Test] Publishing 32KB message (exceeds 5KB limit)...')
+      publisher.publish('freeze/topic', payload, { qos: 0 })
+
+      // Wait for drainTimeout + buffer
+      await delay(DRAIN_TIMEOUT + 1500)
+
+      console.log(`[Test] Client disconnected: ${clientDisconnected}`)
+      console.log(`[Test] Messages received: ${messagesReceived}`)
+
+      // SUCCESS: Client should be disconnected (either by drainTimeout or connection error)
+      // FAILURE: Client stays connected despite being frozen
+      t.assert.strictEqual(clientDisconnected, true,
+        'FAILED: Frozen client should be disconnected by drainTimeout or connection reset')
+      t.assert.strictEqual(messagesReceived, 0,
+        'Frozen client should not receive full message')
+
+      console.log('[Test] SUCCESS: Frozen client was disconnected')
+
+      subscriber.end(true)
+      publisher.end(true)
+    } finally {
+      await proxy.remove()
+      broker.close()
+      server.close()
+    }
+  })
+
+  test('LARGE DATA: filling ToxiProxy buffer triggers real TCP backpressure', async (t) => {
+    // ToxiProxy buffers ~25MB internally. If we send MORE than that,
+    // the buffer fills and TCP backpressure kicks in.
+    // This test proves the full chain works with realistic proxy conditions.
+
+    const DRAIN_TIMEOUT = 2000
+
+    const broker = await Aedes.createBroker({
+      concurrency: 1,
+      drainTimeout: DRAIN_TIMEOUT
+    })
+    const server = createServer(broker.handle)
+    await new Promise(resolve => server.listen(0, '0.0.0.0', resolve))
+    const brokerPort = server.address().port
+
+    const hostIp = process.platform === 'darwin' ? 'host.docker.internal' : '172.17.0.1'
+
+    const proxy = await toxiproxy.createProxy({
+      name: 'aedes-large-data',
+      listen: `0.0.0.0:${PROXY_LISTEN_PORT}`,
+      upstream: `${hostIp}:${brokerPort}`
+    })
+
+    // Very slow bandwidth - 1KB/s causes TCP backpressure after ~1-2MB
+    await proxy.addToxic({
+      name: 'bandwidth-crawl',
+      type: 'bandwidth',
+      stream: 'downstream',
+      toxicity: 1,
+      attributes: {
+        rate: 1 // 1 KB/s - painfully slow
+      }
+    })
+
+    console.log('[Test] Bandwidth: 1KB/s - backpressure expected at ~1-2MB')
+
+    let clientDisconnected = false
+    let writeReturnedFalse = false
+
+    broker.on('client', (client) => {
+      if (client.id === 'large-data-sub') {
+        const origWrite = client.conn.write.bind(client.conn)
+        client.conn.write = function (...args) {
+          const result = origWrite(...args)
+          if (result === false && !writeReturnedFalse) {
+            writeReturnedFalse = true
+            console.log('[Test] write() returned false - TCP BACKPRESSURE!')
+          }
+          return result
+        }
+      }
+    })
+
+    try {
+      const subscriber = await mqtt.connectAsync({
+        host: proxyHost,
+        port: proxyMappedPort,
+        keepalive: 0,
+        clientId: 'large-data-sub'
+      })
+      await subscriber.subscribeAsync('large/#', { qos: 0 })
+
+      subscriber.on('close', () => {
+        clientDisconnected = true
+        console.log('[Test] Client disconnected')
+      })
+
+      const publisher = await mqtt.connectAsync({
+        port: brokerPort,
+        keepalive: 0,
+        clientId: 'large-data-pub'
+      })
+
+      // 1MB messages × 5 = 5MB - enough to trigger backpressure at ~1-2MB
+      const payload = Buffer.alloc(1024 * 1024, 'L') // 1MB
+      const numMessages = 5
+      let sent = 0
+
+      console.log(`[Test] Publishing ${numMessages} x 1MB = 5MB total...`)
+      const startTime = Date.now()
+
+      for (let i = 0; i < numMessages; i++) {
+        publisher.publish('large/topic', payload, { qos: 0 })
+        sent++
+        if (i % 5 === 0) {
+          console.log(`[Test] Sent ${sent}MB...`)
+        }
+        // Small delay to let events process
+        await delay(10)
+      }
+
+      // Wait for drainTimeout to potentially fire
+      console.log(`[Test] Waiting for drainTimeout (${DRAIN_TIMEOUT}ms)...`)
+      await delay(DRAIN_TIMEOUT + 1000)
+
+      const elapsed = Date.now() - startTime
+
+      console.log(`[Test] Elapsed: ${elapsed}ms`)
+      console.log(`[Test] Backpressure (write=false): ${writeReturnedFalse}`)
+      console.log(`[Test] Client disconnected: ${clientDisconnected}`)
+
+      // SUCCESS: Either backpressure occurred OR client disconnected
+      // This proves large data volumes DO cause real TCP effects through ToxiProxy
+      const backpressureOccurred = writeReturnedFalse || clientDisconnected
+
+      t.assert.ok(backpressureOccurred,
+        'FAILED: With 30MB at 1KB/s, should trigger backpressure or disconnect')
+
+      if (writeReturnedFalse) {
+        console.log('[Test] SUCCESS: TCP backpressure achieved via ToxiProxy buffer fill!')
+      }
+      if (clientDisconnected) {
+        console.log('[Test] SUCCESS: drainTimeout disconnected slow client!')
+      }
+
+      subscriber.end(true)
+      publisher.end(true)
+    } finally {
+      await proxy.remove()
+      broker.close()
+      server.close()
+    }
+  })
+
+  test('QoS 1: slow client delays acknowledgments, broker tracks pending messages', async (t) => {
+    // QoS 1 requires PUBACK from client. With a slow client:
+    // 1. Broker sends PUBLISH
+    // 2. Slow client receives it slowly
+    // 3. Client sends PUBACK slowly (upstream also affected by proxy)
+    // 4. Broker waits for PUBACK before considering delivery complete
+    //
+    // This tests a DIFFERENT blocking pattern than write-side backpressure.
+
+    const broker = await Aedes.createBroker({ concurrency: 5 })
+    const server = createServer(broker.handle)
+    await new Promise(resolve => server.listen(0, '0.0.0.0', resolve))
+    const brokerPort = server.address().port
+
+    const hostIp = process.platform === 'darwin' ? 'host.docker.internal' : '172.17.0.1'
+
+    const proxy = await toxiproxy.createProxy({
+      name: 'aedes-qos1',
+      listen: `0.0.0.0:${PROXY_LISTEN_PORT}`,
+      upstream: `${hostIp}:${brokerPort}`
+    })
+
+    // Slow BOTH directions - affects PUBLISH downstream and PUBACK upstream
+    await proxy.addToxic({
+      name: 'latency-both',
+      type: 'latency',
+      stream: 'downstream',
+      toxicity: 1,
+      attributes: {
+        latency: 500, // 500ms per packet
+        jitter: 100
+      }
+    })
+    await proxy.addToxic({
+      name: 'latency-upstream',
+      type: 'latency',
+      stream: 'upstream',
+      toxicity: 1,
+      attributes: {
+        latency: 500, // 500ms for PUBACK to return
+        jitter: 100
+      }
+    })
+
+    console.log('[Test] QoS 1 with 500ms latency each direction (1s round-trip)')
+
+    try {
+      // Slow subscriber through proxy
+      const slowSubscriber = await mqtt.connectAsync({
+        host: proxyHost,
+        port: proxyMappedPort,
+        keepalive: 0,
+        clientId: 'qos1-slow'
+      })
+      await slowSubscriber.subscribeAsync('qos1/#', { qos: 1 }) // QoS 1!
+
+      let slowReceived = 0
+      slowSubscriber.on('message', () => {
+        slowReceived++
+        console.log(`[Test] Slow client received message ${slowReceived}`)
+      })
+
+      // Fast subscriber directly connected
+      const fastSubscriber = await mqtt.connectAsync({
+        port: brokerPort,
+        keepalive: 0,
+        clientId: 'qos1-fast'
+      })
+      await fastSubscriber.subscribeAsync('qos1/#', { qos: 1 })
+
+      let fastReceived = 0
+      fastSubscriber.on('message', () => {
+        fastReceived++
+      })
+
+      const publisher = await mqtt.connectAsync({
+        port: brokerPort,
+        keepalive: 0,
+        clientId: 'qos1-pub'
+      })
+
+      // Small messages, QoS 1
+      const payload = Buffer.alloc(1024, 'Q') // 1KB
+      const numMessages = 5
+      let publishAcked = 0
+
+      console.log(`[Test] Publishing ${numMessages} x 1KB messages with QoS 1...`)
+      const startTime = Date.now()
+
+      // QoS 1 publish - callback fires when broker ACKs our publish
+      const publishPromises = []
+      for (let i = 0; i < numMessages; i++) {
+        publishPromises.push(new Promise(resolve => {
+          publisher.publish('qos1/topic', payload, { qos: 1 }, (err) => {
+            publishAcked++
+            console.log(`[Test] Publish ${publishAcked} ACKed by broker`)
+            resolve(err)
+          })
+        }))
+      }
+
+      await Promise.all(publishPromises)
+
+      // Wait for slow client to receive
+      await delay(5000) // 5 messages × 1s round-trip ≈ 5s
+
+      const elapsed = Date.now() - startTime
+
+      console.log(`[Test] Elapsed: ${elapsed}ms`)
+      console.log(`[Test] Fast subscriber received: ${fastReceived}/${numMessages}`)
+      console.log(`[Test] Slow subscriber received: ${slowReceived}/${numMessages}`)
+
+      // SUCCESS criteria:
+      // - Fast subscriber should receive all messages quickly
+      // - Slow subscriber should receive all messages (eventually)
+      // - Total time should reflect the latency overhead
+      t.assert.strictEqual(fastReceived, numMessages,
+        'Fast subscriber must receive all QoS 1 messages')
+      t.assert.ok(slowReceived > 0,
+        'Slow subscriber should receive some QoS 1 messages')
+      t.assert.ok(elapsed > 2000,
+        'QoS 1 with 500ms×2 latency should take noticeable time')
+
+      console.log('[Test] SUCCESS: QoS 1 works with slow client (latency affects delivery)')
+
+      slowSubscriber.end(true)
+      fastSubscriber.end(true)
+      publisher.end(true)
+    } finally {
+      await proxy.remove()
+      broker.close()
+      server.close()
+    }
+  })
+
+  test('fast subscriber still receives messages when slow subscriber via proxy', async (t) => {
+    // This tests that a fast client (direct connection) continues receiving
+    // even when slow clients (through proxy) are degrading throughput.
+    // Unlike frozen clients, slow clients don't cause complete deadlock.
+
+    const broker = await Aedes.createBroker({ concurrency: 5 })
+    const server = createServer(broker.handle)
+    await new Promise(resolve => server.listen(0, '0.0.0.0', resolve))
+    const brokerPort = server.address().port
+
+    const hostIp = process.platform === 'darwin' ? 'host.docker.internal' : '172.17.0.1'
+
+    const proxy = await toxiproxy.createProxy({
+      name: 'aedes-fast-slow-test',
+      listen: `0.0.0.0:${PROXY_LISTEN_PORT}`,
+      upstream: `${hostIp}:${brokerPort}`
+    })
+
+    // Moderate bandwidth limit - slow but functional
+    await proxy.addToxic({
+      name: 'bandwidth-slow',
+      type: 'bandwidth',
+      stream: 'downstream',
+      toxicity: 1,
+      attributes: {
+        rate: 10 // 10 KB/s
+      }
+    })
+
+    console.log('[Test] Slow subscriber at 10KB/s, fast subscriber direct')
+
+    try {
+      // Slow subscriber through proxy
+      const slowSubscriber = await mqtt.connectAsync({
+        host: proxyHost,
+        port: proxyMappedPort,
+        keepalive: 0,
+        clientId: 'slow-sub'
+      })
+      await slowSubscriber.subscribeAsync('mixed/#', { qos: 0 })
+
+      let slowReceived = 0
+      slowSubscriber.on('message', () => { slowReceived++ })
+
+      // Fast subscriber directly connected
+      const fastSubscriber = await mqtt.connectAsync({
+        port: brokerPort,
+        keepalive: 0,
+        clientId: 'fast-sub'
+      })
+      await fastSubscriber.subscribeAsync('mixed/#', { qos: 0 })
+
+      let fastReceived = 0
+      fastSubscriber.on('message', () => { fastReceived++ })
+
+      const publisher = await mqtt.connectAsync({
+        port: brokerPort,
+        keepalive: 0,
+        clientId: 'mixed-publisher'
+      })
+
+      // Small messages so slow client can actually receive some
+      const payload = Buffer.alloc(1024, 'M') // 1KB
+      const numMessages = 10
+
+      console.log(`[Test] Publishing ${numMessages} x 1KB messages...`)
+
+      for (let i = 0; i < numMessages; i++) {
+        publisher.publish('mixed/topic', payload, { qos: 0 })
+      }
+
+      // Wait for delivery
+      await delay(3000)
+
+      console.log(`[Test] Fast subscriber received: ${fastReceived}/${numMessages}`)
+      console.log(`[Test] Slow subscriber received: ${slowReceived}/${numMessages}`)
+
+      // SUCCESS criteria:
+      // - Fast subscriber should receive ALL messages (direct connection)
+      // - Slow subscriber should receive SOME messages (slow but not frozen)
+      t.assert.strictEqual(fastReceived, numMessages,
+        'Fast subscriber must receive all messages')
+      t.assert.ok(slowReceived > 0,
+        'Slow subscriber should receive some messages (not frozen)')
+
+      console.log('[Test] SUCCESS: Slow client does not block fast client delivery')
+
+      slowSubscriber.end(true)
+      fastSubscriber.end(true)
+      publisher.end(true)
+    } finally {
+      await proxy.remove()
+      broker.close()
+      server.close()
+    }
+  })
+})

--- a/test/drain-toxiproxy.js
+++ b/test/drain-toxiproxy.js
@@ -38,10 +38,6 @@ import { shouldSkipOnWindowsAndMac } from './helper.js'
 // Issues: "Could not find a working container runtime strategy" (Mac)
 //         "invalid volume specification" for Docker socket (Windows)
 const shouldSkip = shouldSkipOnWindowsAndMac()
-if (shouldSkip) {
-  console.log('Skipping drain-toxiproxy tests on Windows/macOS (Docker/testcontainers not available)')
-  process.exit(0)
-}
 
 // ToxiProxy configuration
 const TOXIPROXY_API_PORT = 8474
@@ -53,7 +49,7 @@ let proxyHost
 let proxyApiPort
 let proxyMappedPort
 
-describe('ToxiProxy: realistic slow client behavior', async () => {
+describe('ToxiProxy: realistic slow client behavior', { skip: shouldSkip }, async () => {
   before(async () => {
     console.log('[Setup] Starting ToxiProxy container...')
 

--- a/test/drain-toxiproxy.js
+++ b/test/drain-toxiproxy.js
@@ -32,12 +32,16 @@ import mqtt from 'mqtt'
 import { GenericContainer, Wait } from 'testcontainers'
 import { Toxiproxy } from 'toxiproxy-node-client'
 import { Aedes } from '../aedes.js'
-import { skipOnWindowsAndMac } from './helper.js'
+import { shouldSkipOnWindowsAndMac } from './helper.js'
 
-// Skip on Windows/Mac - Docker/testcontainers not reliably available on CI runners
+// Check if we should skip tests on Windows/macOS
 // Issues: "Could not find a working container runtime strategy" (Mac)
 //         "invalid volume specification" for Docker socket (Windows)
-skipOnWindowsAndMac('drain-toxiproxy')
+const shouldSkip = shouldSkipOnWindowsAndMac()
+if (shouldSkip) {
+  console.log('Skipping drain-toxiproxy tests on Windows/macOS (Docker/testcontainers not available)')
+  process.exit(0)
+}
 
 // ToxiProxy configuration
 const TOXIPROXY_API_PORT = 8474
@@ -76,7 +80,6 @@ describe('ToxiProxy: realistic slow client behavior', async () => {
       await toxiproxyContainer.stop()
     }
   })
-
   test('INSIGHT: slow client (via ToxiProxy) vs frozen client (readStop) behavior', async (t) => {
     // This test demonstrates the KEY DIFFERENCE between slow and frozen clients:
     // - SLOW client (ToxiProxy): Data flows slowly. Messages eventually arrive.

--- a/test/drain-toxiproxy.js
+++ b/test/drain-toxiproxy.js
@@ -32,6 +32,12 @@ import mqtt from 'mqtt'
 import { GenericContainer, Wait } from 'testcontainers'
 import { Toxiproxy } from 'toxiproxy-node-client'
 import { Aedes } from '../aedes.js'
+import { skipOnWindowsAndMac } from './helper.js'
+
+// Skip on Windows/Mac - Docker/testcontainers not reliably available on CI runners
+// Issues: "Could not find a working container runtime strategy" (Mac)
+//         "invalid volume specification" for Docker socket (Windows)
+skipOnWindowsAndMac('drain-toxiproxy')
 
 // ToxiProxy configuration
 const TOXIPROXY_API_PORT = 8474

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,9 +1,24 @@
 import { setTimeout as delay } from 'node:timers/promises'
 import { duplexPair, Transform } from 'node:stream'
+import { platform } from 'node:os'
 import mqtt from 'mqtt-packet'
 import { Aedes } from '../aedes.js'
 
 let clients = 0
+
+/**
+ * Skip tests on Windows and macOS platforms
+ * These platforms often lack proper support for certain network features
+ * like socket.readStop() or have issues with Docker/Testcontainers
+ * @param {string} testName - Name of the test suite for logging
+ */
+export function skipOnWindowsAndMac (testName) {
+  const os = platform()
+  if (os === 'win32' || os === 'darwin') {
+    console.log(`Skipping ${testName} tests on ${os}`)
+    process.exit(0)
+  }
+}
 
 export function setup (broker) {
   const [client, server] = duplexPair()

--- a/test/helper.js
+++ b/test/helper.js
@@ -7,17 +7,14 @@ import { Aedes } from '../aedes.js'
 let clients = 0
 
 /**
- * Skip tests on Windows and macOS platforms
+ * Check if tests should be skipped on Windows and macOS platforms
  * These platforms often lack proper support for certain network features
  * like socket.readStop() or have issues with Docker/Testcontainers
- * @param {string} testName - Name of the test suite for logging
+ * @returns {boolean} true if tests should be skipped on this platform
  */
-export function skipOnWindowsAndMac (testName) {
+export function shouldSkipOnWindowsAndMac () {
   const os = platform()
-  if (os === 'win32' || os === 'darwin') {
-    console.log(`Skipping ${testName} tests on ${os}`)
-    process.exit(0)
-  }
+  return os === 'win32' || os === 'darwin'
 }
 
 export function setup (broker) {

--- a/test/not-blocking.js
+++ b/test/not-blocking.js
@@ -7,7 +7,7 @@ import { Aedes } from '../aedes.js'
 test('connect 500 concurrent clients', async (t) => {
   t.plan(3)
 
-  const broker = await Aedes.createBroker()
+  const broker = await Aedes.createBroker({ drainTimeout: 0 }) // Disable for high-load test
   const server = createServer(broker.handle)
   t.after(() => {
     broker.close()
@@ -60,7 +60,7 @@ for (const [title, brokerOpts, subscription] of
   test(`do not block ${title}`, async (t) => {
     t.plan(3)
 
-    const broker = await Aedes.createBroker(brokerOpts)
+    const broker = await Aedes.createBroker({ ...brokerOpts, drainTimeout: 0 }) // Disable for high-throughput test
     const server = createServer(broker.handle)
     t.after(() => {
       broker.close()

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -75,7 +75,7 @@ export interface AedesOptions {
   concurrency?: number;
   heartbeatInterval?: number;
   connectTimeout?: number;
-  drainTimeout?: number;
+  drainTimeout?: number; // default: 60000 (60 seconds)
   keepaliveLimit?: number;
   queueLimit?: number;
   maxClientsIdLength?: number;

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -75,6 +75,7 @@ export interface AedesOptions {
   concurrency?: number;
   heartbeatInterval?: number;
   connectTimeout?: number;
+  drainTimeout?: number;
   keepaliveLimit?: number;
   queueLimit?: number;
   maxClientsIdLength?: number;


### PR DESCRIPTION
When a client's TCP buffer fills and it stops reading, the broker waits indefinitely for the 'drain' event, blocking message delivery to ALL subscribers.

This proof of concept implements a drainTimeout option (disabled by default  for backwards compatibility) that sets a maximum time to wait for drain. After the timeout, the slow client is disconnected and delivery continues.

Changes:
   - Add drainTimeout option to Aedes constructor (default: 0 = disabled)
   - Implement drain timeout logic in lib/write.js
   - Add TypeScript type definition
   - Add comprehensive tests (unit + E2E with readStop() + ToxiProxy)
   - Update documentation with recommendations
   
The solution based on timeouts might not be ideal but brings a quick fix on the table for this issue and is good enough to start the discussion.