### PR TITLE
fix: add types condition to package.json exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
 	"name": "aedes",
 	"version": "1.0.0",
 	"description": "Stream-based MQTT broker",
-	"exports": "./aedes.js",
+	"exports": {
+		".": {
+			"types": "./aedes.d.ts",
+			"default": "./aedes.js"
+		}
+	},
 	"type": "module",
 	"types": "aedes.d.ts",
 	"scripts": {


### PR DESCRIPTION
## Summary

- Adds a `types` condition to the `exports` field in `package.json` so TypeScript can resolve type declarations when using `moduleResolution: "node16"`, `"nodenext"`, or `"bundler"`
- Without this, users get `TS2305: Module '"aedes"' has no exported member 'Aedes'` because TypeScript ignores the top-level `"types"` field when the `exports` field is present

Closes #1080

## Test plan

- [x] `npm run test:typescript` (tsd) passes
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)