### PR TITLE
fix: add .js extensions to .d.ts imports for node16 resolution

### DIFF
--- a/aedes.d.ts
+++ b/aedes.d.ts
@@ -1,3 +1,3 @@
-export * from './types/instance'
-export * from './types/packet'
-export * from './types/client'
+export * from './types/instance.js'
+export * from './types/packet.js'
+export * from './types/client.js'

--- a/test/types/aedes.test-d.ts
+++ b/test/types/aedes.test-d.ts
@@ -7,7 +7,7 @@ import type {
   Connection
 } from '../../aedes.js'
 import { Aedes } from '../../aedes.js'
-import type { AedesPublishPacket, ConnackPacket, ConnectPacket, PingreqPacket, PublishPacket, PubrelPacket, Subscription, SubscribePacket, UnsubscribePacket } from '../../types/packet'
+import type { AedesPublishPacket, ConnackPacket, ConnectPacket, PingreqPacket, PublishPacket, PubrelPacket, Subscription, SubscribePacket, UnsubscribePacket } from '../../types/packet.js'
 import { expectType } from 'tsd'
 
 // Aedes server

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -5,8 +5,8 @@ import {
   Subscription,
   Subscriptions,
   UnsubscribePacket
-} from './packet'
-import { Connection } from './instance'
+} from './packet.js'
+import { Connection } from './instance.js'
 import { EventEmitter } from 'node:events'
 
 export interface Client extends EventEmitter {

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -1,7 +1,7 @@
 import { Duplex } from 'node:stream'
 import { Socket } from 'node:net'
 import { IncomingMessage } from 'node:http'
-import { Client } from './client'
+import { Client } from './client.js'
 import type {
   AedesPublishPacket,
   ConnectPacket,
@@ -10,7 +10,7 @@ import type {
   PingreqPacket,
   PublishPacket,
   PubrelPacket
-} from './packet'
+} from './packet.js'
 import { EventEmitter } from 'node:events'
 
 type LastHearthbeatTimestamp = Date

--- a/types/packet.d.ts
+++ b/types/packet.d.ts
@@ -9,7 +9,7 @@ import {
   ISubscription,
   IUnsubscribePacket
 } from 'mqtt-packet'
-import { Client } from './client'
+import { Client } from './client.js'
 
 export type SubscribePacket = ISubscribePacket & { cmd: 'subscribe' }
 export type UnsubscribePacket = IUnsubscribePacket & { cmd: 'unsubscribe' }


### PR DESCRIPTION
## Summary
- Adds `.js` extensions to all relative imports in `.d.ts` type definition files
- Fixes TypeScript `moduleResolution: "node16"` failing to resolve types when importing `aedes`

Closes #1082

## Details

With `moduleResolution: "node16"` and `"type": "module"`, TypeScript strictly requires file extensions on relative imports. PR #1081 added the `types` condition to `package.json` exports, allowing TypeScript to find the entry `aedes.d.ts`, but the internal relative imports within the `.d.ts` files still lacked `.js` extensions, causing resolution failures.

**Files changed:**
- `aedes.d.ts` — entry point re-exports
- `types/client.d.ts` — imports from `packet` and `instance`
- `types/instance.d.ts` — imports from `client` and `packet`
- `types/packet.d.ts` — imports from `client`
- `test/types/aedes.test-d.ts` — test import from `types/packet`

## Test plan
- [x] `npm run test:typescript` (tsd) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)