### PR TITLE
types: add missing decodeProtocol, trustProxy, trustedProxies to AedesOptions

### DIFF
--- a/test/types/aedes.test-d.ts
+++ b/test/types/aedes.test-d.ts
@@ -20,6 +20,9 @@ const broker = new Aedes({
   connectTimeout: 30000,
   maxClientsIdLength: 23,
   keepaliveLimit: 0,
+  trustProxy: true,
+  trustedProxies: ['127.0.0.1'],
+  decodeProtocol: (client: Client, buffer: Buffer) => buffer,
   preConnect: (client: Client, packet: ConnectPacket, callback) => {
     if (client.req) {
       callback(new Error('not websocket stream'), false)

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -68,6 +68,11 @@ type PublishedHandler = (
   callback: (error?: Error | null) => void
 ) => void
 
+type DecodeProtocolHandler = (
+  client: Client,
+  buffer: Buffer
+) => any
+
 export interface AedesOptions {
   mq?: any;
   id?: string;
@@ -79,6 +84,9 @@ export interface AedesOptions {
   keepaliveLimit?: number;
   queueLimit?: number;
   maxClientsIdLength?: number;
+  decodeProtocol?: DecodeProtocolHandler;
+  trustProxy?: boolean;
+  trustedProxies?: string[];
   preConnect?: PreConnectHandler;
   authenticate?: AuthenticateHandler;
   authorizePublish?: AuthorizePublishHandler;


### PR DESCRIPTION
Closes #1089.

Three constructor options are read in the `aedes.js` constructor and have `defaultOptions` entries, but were missing from the `AedesOptions` interface in `types/instance.d.ts`, so a TypeScript caller passing any of them got a type error:

- `decodeProtocol` (default `null`)
- `trustProxy` (default `false`)
- `trustedProxies` (default `[]`)

### Change
- Add the three to `AedesOptions`. `trustProxy: boolean`, `trustedProxies: string[]`, and a `DecodeProtocolHandler` for `decodeProtocol` — typed permissively (`(client, buffer) => any`) since it's consumed by external transports (e.g. aedes-server-factory) and has no fixed return contract here. Happy to tighten it if you have a canonical signature in mind.
- Exercise all three in `test/types/aedes.test-d.ts` to prevent re-drift.

Types-only / no runtime change. Pre-existing (not MQTT 5.0-related); split out of #1088 to keep that PR's scope tight, as agreed. `tsd` green.