### PR TITLE
fix(connect): reject zero-length ClientId with CleanSession=0 on MQTT 3.1/3.1.1

### DIFF
--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -151,6 +151,15 @@ function init (client, packet, done) {
   if (client.broker.keepaliveLimit && packet.protocolVersion < 5 && (!packet.keepalive || packet.keepalive > client.broker.keepaliveLimit)) {
     returnCode = 6
   }
+  // [MQTT-3.1.3-7/8] v3/v4: a zero-byte ClientId requires CleanSession = 1; a
+  // zero-byte ClientId with CleanSession 0 must be rejected with return code
+  // 0x02 (identifier rejected) and the connection closed. MQTT 5.0 is
+  // intentionally different — it allows a zero-byte ClientId and assigns one
+  // (reported via the Assigned Client Identifier property, see below) — so this
+  // guard is gated on protocolVersion < 5.
+  if (packet.protocolVersion < 5 && clientId.length === 0 && packet.clean === false) {
+    returnCode = 2
+  }
   if (returnCode > 0) {
     const error = new Error(errorMessages[returnCode])
     error.errorCode = returnCode

--- a/test/connect.js
+++ b/test/connect.js
@@ -143,36 +143,52 @@ test('reject clients with no clientId running on MQTT 3.1.0', { skip: true }, as
   ])
 })
 
-// TODO: test fails because Aedes does not reject this
-// remove { skip: true} once this is fixed
-// [MQTT-3.1.3-7], Guarded in mqtt-packet
-test('reject clients without clientid and clean=false on MQTT 3.1.1', { skip: true }, async (t) => {
-  t.plan(2)
+// [MQTT-3.1.3-7], [MQTT-3.1.3-8]: a zero-byte ClientId with CleanSession = 0
+// must be rejected with return code 0x02 (identifier rejected), then the
+// connection closed. mqtt-packet guards this on encode, so we send the raw
+// bytes rather than going through s.inStream.write.
+test('reject clients with zero-byte clientid and clean=false on MQTT 3.1.1', async (t) => {
+  t.plan(5)
 
   const broker = await Aedes.createBroker()
   t.after(() => broker.close())
   const s = setup(broker)
 
-  // s.inStream.write throws an error when trying to write illegal packets
-  // so we so we use the encoded version
-  const sendPacket = () => {
-    // cmd: 'connect', protocolId: 'MQTT', protocolVersion: 4, clean: false, clientId: '', keepalive: 0
-    const rawPacket = '10 0C 00 04 4D 51 54 54 04 00 00 00 00 00'
-    rawWrite(s, rawPacket)
-  }
+  // Subscribe before writing so the rejection error is never missed.
+  const errorPromise = once(broker, 'connectionError')
 
-  const checkDisconnect = async () => {
-    const [client, err] = await once(broker, 'connectionError')
-    t.assert.true(client, 'client is there')
-    t.assert.equal(err.message, 'clientId must be given if cleanSession set to 0')
-    t.assert.equal(broker.connectedClients, 0)
-  }
-  // run parallel
-  await Promise.all([
-    checkNoPacket(t, s),
-    checkDisconnect(),
-    sendPacket()
-  ])
+  // cmd: 'connect', protocolId: 'MQTT', protocolVersion: 4, clean: false, clientId: '', keepalive: 0
+  rawWrite(s, '10 0C 00 04 4D 51 54 54 04 00 00 00 00 00')
+
+  const connack = await nextPacket(s)
+  t.assert.equal(connack.cmd, 'connack')
+  t.assert.equal(connack.returnCode, 2, 'connack return code is 2 (identifier rejected)')
+
+  const [client, err] = await errorPromise
+  t.assert.ok(client, 'client is there')
+  t.assert.equal(err.message, 'identifier rejected')
+  t.assert.equal(broker.connectedClients, 0)
+})
+
+// [MQTT-3.1.3-7/8] apply only to v3/v4. MQTT 5.0 allows a zero-length ClientId
+// regardless of the Clean Start flag — the broker must assign one (reported via
+// the Assigned Client Identifier property) instead of rejecting. Guards the
+// `protocolVersion < 5` carve-out in init(). mqtt-packet refuses to encode an
+// empty clientId with clean=false, so the raw bytes are sent directly.
+test('clients with zero-byte clientid and clean=false on MQTT 5.0 get an assigned clientId', async (t) => {
+  t.plan(3)
+
+  const broker = await Aedes.createBroker()
+  t.after(() => broker.close())
+  const s = setup(broker)
+
+  // cmd: 'connect', protocolVersion: 5, clean: false, clientId: '', keepalive: 0, no properties
+  rawWrite(s, '10 0D 00 04 4D 51 54 54 05 00 00 00 00 00 00')
+
+  const [client] = await once(broker, 'clientReady')
+  t.assert.equal(broker.connectedClients, 1)
+  t.assert.equal(client.version, 5)
+  t.assert.ok(client.id.startsWith('aedes_'))
 })
 
 test('clients without clientid and clean=true on MQTT 3.1.1 will get a generated clientId', async (t) => {

--- a/test/connect.js
+++ b/test/connect.js
@@ -148,14 +148,16 @@ test('reject clients with no clientId running on MQTT 3.1.0', { skip: true }, as
 // connection closed. mqtt-packet guards this on encode, so we send the raw
 // bytes rather than going through s.inStream.write.
 test('reject clients with zero-byte clientid and clean=false on MQTT 3.1.1', async (t) => {
-  t.plan(5)
+  t.plan(6)
 
   const broker = await Aedes.createBroker()
   t.after(() => broker.close())
   const s = setup(broker)
 
-  // Subscribe before writing so the rejection error is never missed.
+  // Subscribe before writing so neither the rejection error nor the connection
+  // close is missed (both can fire before the awaits below).
   const errorPromise = once(broker, 'connectionError')
+  const closePromise = once(s.conn, 'close')
 
   // cmd: 'connect', protocolId: 'MQTT', protocolVersion: 4, clean: false, clientId: '', keepalive: 0
   rawWrite(s, '10 0C 00 04 4D 51 54 54 04 00 00 00 00 00')
@@ -168,6 +170,10 @@ test('reject clients with zero-byte clientid and clean=false on MQTT 3.1.1', asy
   t.assert.ok(client, 'client is there')
   t.assert.equal(err.message, 'identifier rejected')
   t.assert.equal(broker.connectedClients, 0)
+
+  // [MQTT-3.1.3-8] mandates the network connection is closed after the CONNACK.
+  await closePromise
+  t.assert.ok(s.conn.destroyed, 'connection closed after rejection')
 })
 
 // [MQTT-3.1.3-7/8] apply only to v3/v4. MQTT 5.0 allows a zero-length ClientId


### PR DESCRIPTION
## Summary

For MQTT 3.1.1 (and 3.1.0), a CONNECT with a **zero-length Client Identifier** and **`CleanSession = 0`** must be rejected with CONNACK return code `0x02` (Identifier rejected) and the connection closed. aedes instead **accepted** it and assigned a generated id, regardless of the clean flag.

Surfaced by the new MQTT compatibility workflow (Eclipse Paho interop suite) — `test_zero_length_clientid` failed for v3.1.1.

Closes #1095

## Spec

> **[MQTT-3.1.3-7]** If the Client supplies a zero-byte ClientId, the Client MUST also set CleanSession to 1.
>
> **[MQTT-3.1.3-8]** If the Client supplies a zero-byte ClientId with CleanSession set to 0, the Server MUST respond to the CONNECT Packet with a CONNACK return code 0x02 (Identifier rejected) and then close the Network Connection.

(MQTT 3.1.1, §3.1.3.1 Client Identifier.)

## Fix

`init()` in `lib/handlers/connect.js` now sets `returnCode = 2` alongside the other pre-acceptance checks when `protocolVersion < 5 && clientId.length === 0 && packet.clean === false`. The existing reject path then sends the CONNACK and closes the connection.

The guard is gated on `protocolVersion < 5`, so **MQTT 5.0 is intentionally unchanged**: a zero-length Client Identifier is still allowed and the broker assigns one, reported via the Assigned Client Identifier property (`client._assignedClientId`).

Behaviour matrix:

| version | clientId | clean | result |
|---|---|---|---|
| v3/v4 | empty | `false` | **rejected, return code 2** (new) |
| v3/v4 | empty | `true` | generated id (unchanged) |
| v3/v4 | non-empty | `false` | accepted (unchanged) |
| v5 | empty | any | assigned id via property (unchanged) |

## Tests

- `test/connect.js`: un-skipped and rewrote the previously-skipped v3.1.1 reject test to assert the CONNACK return code is `2` and the connection is closed (`connectionError` with `identifier rejected`, `connectedClients === 0`).
- `test/connect.js`: added a v5 carve-out test confirming an empty ClientId with `clean=false` still gets an assigned id (no rejection). Both use raw bytes because mqtt-packet refuses to *encode* an empty ClientId with `clean=false`.

Full unit suite passes (365 pass, 0 fail) and lint is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)