### PR TITLE
Security: Unvalidated Topic Length and Structure in publish.js

### DIFF
--- a/lib/handlers/publish.js
+++ b/lib/handlers/publish.js
@@ -22,6 +22,10 @@ const publishActions = [
 function handlePublish (client, packet, done) {
   const topic = packet.topic
   let err
+  if (typeof topic !== 'string') {
+    err = new Error('topic must be a string')
+    return done(err)
+  }
   if (topic.length === 0) {
     err = new Error('empty topic not allowed in PUBLISH')
     return done(err)


### PR DESCRIPTION
## Summary

Security: Unvalidated Topic Length and Structure in publish.js

## Problem

**Severity**: `Medium` | **File**: `lib/handlers/publish.js:L22`

In `lib/handlers/publish.js`, the `handlePublish` function validates topic characters (`#`, `+`) and checks `topicLevelCount`, but does not enforce a maximum topic length. MQTT spec allows topics up to 65535 bytes, but extremely long topics could cause DoS through memory exhaustion. Additionally, the `topicLevelCount` function in `lib/utils.js` uses a simple loop that could be slow for very long topics (though O(n) is acceptable). More critically, the `packet.topic` is used directly without ensuring it's a string, which could cause TypeError crashes.

## Solution

Add explicit validation that `packet.topic` is a string before processing. Consider adding a maximum topic length check (e.g., 65535 bytes or a configurable limit) to prevent memory exhaustion attacks.

## Changes

- `lib/handlers/publish.js` (modified)